### PR TITLE
feat: SEP-58 External Account API module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,43 +1,128 @@
 ==================
 Django Polaris BPV
 ==================
-**Note**: This project was originally developed by Stellar Development Foundation and is now maintained by `BP Ventures <https://www.bpventures.us/>`_.
 
-.. image:: https://img.shields.io/github/actions/workflow/status/bp-ventures/django-polaris-bpv/test.yml?branch=master
-    :alt: GitHub Workflow Status
+*A modernised, actively maintained fork of* `django-polaris <https://github.com/stellar/django-polaris>`_ *from the Stellar Development Foundation.*
+
+|build| |coverage| |pypi| |python| |django| |license|
+
+.. |build| image:: https://img.shields.io/github/actions/workflow/status/bp-ventures/django-polaris-bpv/test.yml?branch=master&style=flat-square
+    :alt: Build
     :target: https://github.com/bp-ventures/django-polaris-bpv/actions
 
-.. image:: https://codecov.io/gh/bp-ventures/django-polaris-bpv/branch/master/graph/badge.svg
-    :alt: Code Coverage
+.. |coverage| image:: https://img.shields.io/codecov/c/github/bp-ventures/django-polaris-bpv?style=flat-square
+    :alt: Coverage
     :target: https://codecov.io/gh/bp-ventures/django-polaris-bpv
 
-.. image:: https://img.shields.io/badge/python-3.12%20%7C%203.13-blue?style=shield
-    :alt: Python - Version
-    :target: https://pypi.python.org/pypi/django-polaris
+.. |pypi| image:: https://img.shields.io/pypi/v/django-polaris-bpv?style=flat-square
+    :alt: PyPI
+    :target: https://pypi.python.org/pypi/django-polaris-bpv
 
-.. image:: https://img.shields.io/badge/django-%3E=6.0-blue?style=shield
-    :alt: Django - Version
-    :target: https://pypi.python.org/pypi/django-polaris
+.. |python| image:: https://img.shields.io/badge/python-3.12%20%7C%203.13-blue?style=flat-square
+    :alt: Python
+    :target: https://pypi.python.org/pypi/django-polaris-bpv
 
-.. _github: https://github.com/bp-ventures/django-polaris-bpv
+.. |django| image:: https://img.shields.io/badge/django-%3E%3D%206.0-0C4B33?style=flat-square
+    :alt: Django
+    :target: https://pypi.python.org/pypi/django-polaris-bpv
+
+.. |license| image:: https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square
+    :alt: License
+    :target: https://github.com/bp-ventures/django-polaris-bpv/blob/master/LICENSE
+
+----
+
+Why This Fork?
+--------------
+
+The upstream `django-polaris`_ (v2.6.0) targets Python 3.10+ and Django 4.2.
+This fork brings the stack up to date:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 35
+
+   * -
+     - Upstream (stellar)
+     - **BPV Fork**
+   * - Python
+     - >= 3.10
+     - **>= 3.12**
+   * - Django
+     - >= 4.2
+     - **>= 6.0**
+   * - Django REST Framework
+     - >= 3.12
+     - **>= 3.16**
+   * - stellar-sdk
+     - >= 10
+     - **>= 10** *(aiohttp async transport)*
+   * - pytz
+     - required
+     - **removed** *(stdlib zoneinfo)*
+
+**Python 3.12+**
+    ~25 % average speed-up over 3.10 thanks to the Faster CPython project
+    (PEP 659 adaptive interpreter, inlined calls, optimised comprehensions).
+
+**Django 6.0**
+    Latest release track with improved async views and native ``zoneinfo`` support.
+
+**stellar-sdk >= 10 with aiohttp**
+    Async-first Stellar SDK, tested against current v13.x releases.
+
+**No pytz**
+    Replaced by the stdlib ``zoneinfo`` module — one fewer dependency to manage.
+
+----
+
+Quick Start
+-----------
+
+.. code-block:: bash
+
+   pip install django-polaris-bpv
+
+Add to ``INSTALLED_APPS``:
+
+.. code-block:: python
+
+   INSTALLED_APPS = [
+       ...,
+       "polaris",
+   ]
+
+See the full `documentation`_ for integration details, or explore the
+`reference server`_ with the `demo wallet`_.
+
+----
+
+About Polaris
+-------------
+
+Polaris is an extendable `django app`_ for Stellar Ecosystem Proposal (SEP)
+implementations. Using Polaris, you can run a web server supporting any
+combination of SEP-1, 6, 10, 12, 24, 31, & 38.
+
+----
+
+About BP Ventures
+-----------------
+
+Since 2020, `BP Ventures`_ has helped fintechs, banks, and charities with
+comprehensive blockchain and payment solutions:
+
+- **Anchor in the Box** — Join the Stellar Ecosystem
+- **White label wallet** — No gas fee transfers
+- **Guard / SEP-30** — Key security solutions
+
+Focus on serving your clients while we handle all your blockchain infrastructure needs.
+
+----
+
+.. _django-polaris: https://github.com/stellar/django-polaris
 .. _django app: https://docs.djangoproject.com/en/stable/intro/reusable-apps/
 .. _`demo wallet`: http://demo-wallet.stellar.org
 .. _`reference server`: https://testanchor.stellar.org/.well-known/stellar.toml
 .. _`documentation`: https://django-polaris-bpv.readthedocs.io/
 .. _`BP Ventures`: https://www.bpventures.us/
-
-About BP Ventures
------------------
-Since 2020, BP Ventures has helped fintechs, banks, and charities with comprehensive blockchain and payment solutions. Our turnkey offerings include:
-
-- **Anchor in the Box**: Join the Stellar Ecosystem
-- **White label wallet**: No gas fee transfers
-- **Guard/SEP 30**: Key security solutions
-
-Focus on serving your clients while we handle all your blockchain infrastructure needs.
-
-About Polaris Django BPV
--------------------------
-Polaris is an extendable `django app`_ for Stellar Ecosystem Proposal (SEP) implementations maintained by the `BP Ventures`_ (BPV). Using Polaris, you can run a web server supporting any combination of SEP-1, 6, 10, 12, 24, 31, & 38.
-
-See the complete `documentation`_ for information on how to get started with Polaris. The BPV also runs a `reference server`_ using Polaris that can be tested using our `demo wallet`_.

--- a/docs/bpv/DJANGO_TASKS_PROPOSAL.md
+++ b/docs/bpv/DJANGO_TASKS_PROPOSAL.md
@@ -1,0 +1,312 @@
+# Django 6.0 Tasks Framework Proposal
+
+**Status:** Proposal
+**Created:** January 2026
+**Django Version:** 6.0+ (or 5.2+ with `django-tasks` backport)
+
+## Summary
+
+Django 6.0 introduces a native Tasks framework (`django.tasks`) for running background work. This proposal explores how it could make Polaris more scalable by replacing the current single-instance architecture with a cron + tasks pattern.
+
+---
+
+## Current Architecture
+
+Polaris uses **4 long-running Django management commands** for background processing:
+
+| Command | Purpose | Pattern |
+|---------|---------|---------|
+| `process_pending_deposits` | Submit deposits to Stellar | Async polling + in-memory `asyncio.Queue` |
+| `watch_transactions` | Stream incoming Stellar transactions | SSE streaming from Stellar Horizon |
+| `execute_outgoing_transactions` | Execute off-chain withdrawals | Sync polling loop |
+| `poll_outgoing_transactions` | Poll external transfer status | Sync polling loop |
+
+### Key Characteristics
+
+- **No Celery/Redis** - Uses in-memory asyncio queues + database for state
+- **Database is source of truth** - All transaction state in PostgreSQL/SQLite
+- **Distributed locking** - `PolarisHeartbeat` model ensures single instance for `process_pending_deposits`
+- **Long-lived processes** - Each command runs indefinitely
+- **Per-process deployment** - Typically 4 containers/processes in production
+
+---
+
+## The Scalability Problem
+
+`process_pending_deposits` uses distributed locking to ensure only **ONE instance runs globally**:
+
+```
+┌────────────────────────────────────────┐
+│  process_pending_deposits              │
+│  (ONE instance, heartbeat lock)        │
+│                                        │
+│  polls → checks → submits (serial)     │
+└────────────────────────────────────────┘
+         ⚠️ Single point of failure
+         ⚠️ Can't scale horizontally
+         ⚠️ In-memory queues lost on crash
+```
+
+### Current Internal Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  process_pending_deposits (single long-running process)         │
+│                                                                 │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐      │
+│  │ poll_rails   │───▶│ check_accts  │───▶│ submit_tx    │      │
+│  │ (continuous) │    │ (continuous) │    │ (continuous) │      │
+│  └──────────────┘    └──────────────┘    └──────────────┘      │
+│         │                   │                   │               │
+│         └───────── asyncio.Queue ──────────────┘               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Limitations:**
+- All queues are in-memory (lost on process restart)
+- Single-instance deployment required (heartbeat lock)
+- In-memory locks don't scale across processes
+- Limited observability (manual log inspection)
+
+---
+
+## Proposed Architecture: Cron + Tasks
+
+Decouple **detection** from **execution** using Django 6.0 Tasks:
+
+```
+┌─────────────────┐      ┌─────────────────────────────────┐
+│  Cron (every 10s)│      │  Task Workers (N instances)     │
+│                 │      │                                 │
+│  SELECT pending │      │  ┌─────────┐ ┌─────────┐       │
+│  transactions   │─────▶│  │ task 1  │ │ task 2  │ ...   │
+│                 │      │  │ tx:abc  │ │ tx:def  │       │
+│  enqueue each   │      │  └─────────┘ └─────────┘       │
+└─────────────────┘      └─────────────────────────────────┘
+   ✅ Lightweight           ✅ Horizontally scalable
+   ✅ Stateless             ✅ Parallel processing
+                            ✅ Auto-retry on failure
+```
+
+### Benefits
+
+| Aspect | Current | Cron + Tasks |
+|--------|---------|--------------|
+| **Scalability** | 1 instance max | N workers |
+| **Failure handling** | Manual restart | Auto-retry |
+| **Observability** | Log parsing | Task status/history |
+| **Queue persistence** | In-memory (lost on crash) | Database-backed |
+| **Heartbeat locking** | Required | Not needed |
+| **Complexity** | Asyncio queues | Simpler per-task logic |
+
+---
+
+## Implementation Sketch
+
+### Task Definitions
+
+```python
+# polaris/tasks.py
+from django.tasks import task
+from django.db import transaction as db_transaction
+from polaris.models import Transaction
+
+@task(retries=3, queue_name="deposits")
+def process_deposit(transaction_id):
+    """Process a single deposit - runs in parallel workers."""
+    with db_transaction.atomic():
+        tx = Transaction.objects.select_for_update().get(id=transaction_id)
+        if tx.submission_status != "ready":
+            return  # Already processed or not ready
+
+        # Check account exists on Stellar
+        # Check trustline established
+        # Submit transaction to Stellar
+        ...
+
+@task(retries=3, queue_name="withdrawals")
+def execute_withdrawal(transaction_id):
+    """Execute a single withdrawal off-chain."""
+    tx = Transaction.objects.select_for_update().get(id=transaction_id)
+    if tx.status != "pending_anchor":
+        return
+
+    # Call RailsIntegration.execute_outgoing_transaction()
+    ...
+
+@task(retries=2, queue_name="polling")
+def poll_withdrawal_status(transaction_id):
+    """Poll external status for a single withdrawal."""
+    tx = Transaction.objects.get(id=transaction_id)
+    # Call RailsIntegration.poll_outgoing_transactions()
+    ...
+```
+
+### Cron Job (Enqueuer)
+
+```python
+# polaris/management/commands/enqueue_pending_tasks.py
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from polaris.models import Transaction
+from polaris.tasks import process_deposit, execute_withdrawal
+
+class Command(BaseCommand):
+    help = "Enqueue pending transactions as tasks (run via cron)"
+
+    def handle(self, *args, **options):
+        # Enqueue pending deposits
+        deposits = Transaction.objects.filter(
+            kind=Transaction.KIND.deposit,
+            submission_status="ready",
+            queued_at__isnull=True,
+        )
+        for tx in deposits:
+            tx.queued_at = timezone.now()
+            tx.save(update_fields=["queued_at"])
+            process_deposit.enqueue(transaction_id=str(tx.id))
+
+        # Enqueue pending withdrawals
+        withdrawals = Transaction.objects.filter(
+            kind=Transaction.KIND.withdrawal,
+            status=Transaction.STATUS.pending_anchor,
+            queued_at__isnull=True,
+        )
+        for tx in withdrawals:
+            tx.queued_at = timezone.now()
+            tx.save(update_fields=["queued_at"])
+            execute_withdrawal.enqueue(transaction_id=str(tx.id))
+
+        self.stdout.write(f"Enqueued {deposits.count()} deposits, {withdrawals.count()} withdrawals")
+```
+
+### Django Settings
+
+```python
+# settings.py
+TASKS = {
+    "default": {
+        # Option 1: Database backend (no external deps)
+        "BACKEND": "django_tasks.backends.database.DatabaseBackend",
+
+        # Option 2: Immediate (dev only - runs synchronously)
+        # "BACKEND": "django.tasks.backends.immediate.ImmediateBackend",
+    }
+}
+```
+
+### Deployment
+
+```bash
+# Cron job (every 10 seconds)
+*/10 * * * * python manage.py enqueue_pending_tasks
+
+# Task workers (scale as needed)
+python manage.py db_worker --queue deposits --concurrency 4
+python manage.py db_worker --queue withdrawals --concurrency 2
+python manage.py db_worker --queue polling --concurrency 2
+
+# Keep existing streaming command (can't be task-based)
+python manage.py watch_transactions
+```
+
+---
+
+## Migration Path by Command
+
+| Command | Recommendation | Notes |
+|---------|----------------|-------|
+| `process_pending_deposits` | ✅ **Replace** with cron + tasks | Best scalability gain |
+| `execute_outgoing_transactions` | ✅ **Replace** with cron + tasks | Simple 1:1 mapping |
+| `poll_outgoing_transactions` | ✅ **Replace** with cron + tasks | Simple 1:1 mapping |
+| `watch_transactions` | ❌ **Keep as-is** | SSE streaming doesn't fit task model |
+
+---
+
+## Task Backend Options
+
+Django 6.0 provides the API but not workers. Backend options:
+
+### 1. `django-tasks` DatabaseBackend (Recommended)
+
+- **Pros:** No external dependencies, uses existing database
+- **Cons:** Lower throughput than Redis
+- **Install:** `pip install django-tasks`
+- **Worker:** `python manage.py db_worker`
+
+### 2. Redis Backend
+
+- **Pros:** High throughput, battle-tested
+- **Cons:** Requires Redis infrastructure
+- **Options:** `django-tasks-redis`, custom implementation
+
+### 3. Custom Backend
+
+- Implement `BaseTaskBackend` for specific infrastructure (SQS, RabbitMQ, etc.)
+
+---
+
+## Scheduler Options
+
+For running the enqueuer periodically:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Kubernetes CronJob** | Native K8s, no code | K8s only, 1-min minimum |
+| **systemd timer** | Simple, reliable | Linux only |
+| **Supervisor + loop** | Cross-platform | Custom code |
+| **APScheduler** | Python native | Another dependency |
+| **Management command + sleep** | Simplest | Less precise timing |
+
+---
+
+## Phased Migration Plan
+
+### Phase 1: Add Optional Task Support
+
+- Add `polaris/tasks.py` with task definitions
+- Add `enqueue_pending_tasks` command
+- Document as alternative to existing commands
+- No breaking changes
+
+### Phase 2: Parallel Support
+
+- Both architectures work side-by-side
+- Users choose based on their infrastructure
+- Gather feedback on task-based approach
+
+### Phase 3: Default to Tasks (Major Version)
+
+- Make task-based processing the default
+- Deprecate single-instance commands
+- Provide migration guide
+
+---
+
+## Open Questions
+
+- [ ] Which task backend should Polaris officially recommend?
+- [ ] Should this be opt-in or become the new default?
+- [ ] Minimum Django version: 6.0 only, or support 5.2 with backport?
+- [ ] How to handle idempotency for re-enqueued tasks?
+- [ ] Should we provide a combined worker command?
+
+---
+
+## References
+
+- [Django 6.0 Tasks Documentation](https://docs.djangoproject.com/en/6.0/topics/tasks/)
+- [Django Tasks API Reference](https://docs.djangoproject.com/en/6.0/ref/tasks/)
+- [django-tasks PyPI](https://pypi.org/project/django-tasks/) - Backport for Django 5.2+
+- [Django Forum: django-tasks DEP](https://forum.djangoproject.com/t/django-tasks-bringing-background-workers-in-to-django-core/32967)
+- [A First Look at Django's Background Tasks](https://roam.be/notes/2025/a-first-look-at-djangos-new-background-tasks/)
+
+---
+
+## Current Implementation Reference
+
+- `polaris/management/commands/process_pending_deposits.py`
+- `polaris/management/commands/watch_transactions.py`
+- `polaris/management/commands/execute_outgoing_transactions.py`
+- `polaris/management/commands/poll_outgoing_transactions.py`
+- `polaris/models.py` - `PolarisHeartbeat` model for distributed locking

--- a/docs/bpv/DJANGO_UPGRADE_ANALYSIS_52.md
+++ b/docs/bpv/DJANGO_UPGRADE_ANALYSIS_52.md
@@ -1,0 +1,325 @@
+# Django Upgrade Analysis: 4.2 to 5.2 LTS / 6.0
+
+**Date:** January 2026
+**Current Version:** Django >=4.2
+**Target Versions:** Django 5.2 LTS or Django 6.0
+
+## Executive Summary
+
+The Django Polaris codebase is **mostly compatible** with Django 5.x/6.0, but has one **critical blocker**: active `pytz` usage that must be migrated to Python's `zoneinfo` module. Django 5.0+ completely removed pytz support.
+
+**Recommendation:** Upgrade to **Django 5.2 LTS** (step upgrade). Django 6.0 requires Python 3.12+ which would drop support for Python 3.10/3.11.
+
+---
+
+## Version Requirements Matrix
+
+| Version | Python Requirement | Support Status | Release Date |
+|---------|-------------------|----------------|--------------|
+| Django 4.2 LTS | 3.8+ | Security fixes until Apr 2026 | Apr 2023 |
+| Django 5.0 | 3.10+ | Superseded | Dec 2023 |
+| Django 5.1 | 3.10+ | Superseded | Aug 2024 |
+| Django 5.2 LTS | 3.10+ | Mainstream support until Dec 2027 | Apr 2025 |
+| Django 6.0 | 3.12+ | Current | Dec 2025 |
+
+**Current pyproject.toml:** `python = "^3.10"` (compatible with 5.2 LTS, NOT 6.0)
+
+---
+
+## Historical Upgrade Issues
+
+### Django 4.x Upgrade (2025)
+
+The previous Django 4.2 upgrade (commit `a909eb7`) encountered **cross-origin popup detection issues** that broke the Stellar Demo Wallet integration. This required adding `CrossOriginMiddleware` in `polaris/middleware.py:41-105` to:
+
+- Add CORS headers for SEP-24 URLs
+- Set `Cross-Origin-Opener-Policy: unsafe-none`
+- Modify cookies: `SameSite=Lax` → `SameSite=None; Secure`
+
+**Lesson:** Django security changes can break wallet integrations. Thorough testing with demo-wallet.stellar.org is essential.
+
+---
+
+## Critical Blocker: pytz Usage
+
+**Django 5.0 completely removed pytz support.** The codebase has active pytz usage in 3 files:
+
+### 1. `polaris/middleware.py:36`
+```python
+import pytz
+# ...
+timezone.activate(pytz.timezone(tzname))
+```
+
+### 2. `polaris/sep24/tzinfo.py:28`
+```python
+import pytz
+# ...
+for tz in map(pytz.timezone, pytz.all_timezones_set):
+    if now.astimezone(tz).utcoffset() == offset:
+```
+
+### 3. `polaris/sep24/utils.py:373`
+```python
+import pytz
+# ...
+datetime.now().astimezone(pytz.timezone(timezone)).utcoffset().total_seconds()
+```
+
+### Required Migration
+
+```python
+# BEFORE (pytz)
+import pytz
+tz = pytz.timezone('America/New_York')
+pytz.all_timezones_set
+
+# AFTER (zoneinfo - Python 3.9+)
+from zoneinfo import ZoneInfo
+import zoneinfo
+tz = ZoneInfo('America/New_York')
+zoneinfo.available_timezones()
+```
+
+**Note:** `zoneinfo` requires `tzdata` package on Windows.
+
+---
+
+## Compatibility Analysis
+
+### Fully Compatible (No Changes Required)
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| URL patterns | ✅ | Uses modern `django.urls.path` and `re_path` |
+| Middleware pattern | ✅ | Uses `__init__(get_response)` / `__call__` |
+| Models | ✅ | No `index_together`, uses proper field types |
+| Forms | ✅ | Standard Django forms |
+| Admin | ✅ | Modern `ModelAdmin` patterns |
+| Management commands | ✅ | Modern `BaseCommand` |
+| DRF integration | ✅ | Compatible with Django 5.x |
+| Translation | ✅ | Uses `gettext`/`gettext_lazy` (not deprecated `ugettext`) |
+| Timezone handling | ✅ | Uses `datetime.timezone.utc` (not `django.utils.timezone.utc`) |
+
+### Requires Changes
+
+| Component | Status | Action Required |
+|-----------|--------|-----------------|
+| pytz usage | ❌ | Migrate to `zoneinfo` |
+| `pytz` dependency | ❌ | Remove from pyproject.toml |
+| pyproject.toml classifiers | ⚠️ | Add Django 5.x classifiers |
+| Documentation | ⚠️ | Update `STATICFILES_STORAGE` to `STORAGES` dict |
+
+### Test File Changes
+
+`polaris/tests/sep24/test_tzinfo.py` uses `pytz` and must be updated.
+
+---
+
+## Django 5.x Breaking Changes Relevant to Polaris
+
+### Settings Changes
+
+| Setting | Django 4.2 | Django 5.0+ |
+|---------|------------|-------------|
+| `USE_L10N` | Optional | Removed |
+| `STATICFILES_STORAGE` | Works | Deprecated (use `STORAGES["staticfiles"]`) |
+| `DEFAULT_FILE_STORAGE` | Works | Deprecated (use `STORAGES["default"]`) |
+| `CSRF_COOKIE_MASKED` | Works | Removed |
+
+**Polaris impact:** Documentation mentions `STATICFILES_STORAGE` - should be updated.
+
+### Form Rendering
+
+Django 5.0 changed default form rendering from table-based to div-based. Polaris uses custom templates, so this should not affect functionality but may affect styling.
+
+### Admin Logout
+
+GET requests for logout are no longer supported (must use POST). Polaris admin should be tested.
+
+---
+
+## Django 6.0 Considerations
+
+If targeting Django 6.0:
+
+1. **Python 3.12+ required** - Would drop Python 3.10/3.11 support
+2. **`DEFAULT_AUTO_FIELD`** - Defaults to `BigAutoField` (was `AutoField`)
+3. **URLField** - HTTPS assumed by default
+4. **`Model.save()` positional args** - Must use keyword arguments
+
+**Recommendation:** Not recommended at this time. Django 5.2 LTS provides support until Dec 2027.
+
+---
+
+## Recommended Upgrade Path
+
+### Phase 1: Prepare (Current Django 4.2)
+
+1. **Run deprecation warnings:**
+   ```bash
+   python -Wd manage.py test
+   ```
+
+2. **Install django-upgrade tool:**
+   ```bash
+   pip install django-upgrade
+   django-upgrade --target-version 5.2 polaris/**/*.py
+   ```
+
+3. **Update pyproject.toml:**
+   - Remove `pytz = "*"` dependency
+   - Add `tzdata = {version = "*", markers = "sys_platform == 'win32'"}` for Windows
+
+### Phase 2: Migrate pytz to zoneinfo
+
+**File: `polaris/middleware.py`**
+```python
+# Before
+import pytz
+timezone.activate(pytz.timezone(tzname))
+
+# After
+from zoneinfo import ZoneInfo
+timezone.activate(ZoneInfo(tzname))
+```
+
+**File: `polaris/sep24/tzinfo.py`**
+```python
+# Before
+import pytz
+for tz in map(pytz.timezone, pytz.all_timezones_set):
+
+# After
+from zoneinfo import ZoneInfo, available_timezones
+for tz_name in available_timezones():
+    tz = ZoneInfo(tz_name)
+```
+
+**File: `polaris/sep24/utils.py`**
+```python
+# Before
+import pytz
+datetime.now().astimezone(pytz.timezone(timezone))
+
+# After
+from zoneinfo import ZoneInfo
+datetime.now().astimezone(ZoneInfo(timezone))
+```
+
+### Phase 3: Update Dependencies
+
+**pyproject.toml changes:**
+```toml
+[tool.poetry.dependencies]
+django = ">=5.2"  # Was ">=4.2"
+# Remove: pytz = "*"
+tzdata = {version = "*", markers = "sys_platform == 'win32'"}
+
+[tool.poetry]
+classifiers = [
+    # Add:
+    "Framework :: Django :: 5.2",
+]
+```
+
+### Phase 4: Update Documentation
+
+Update `docs/sep-24.rst` and `CLAUDE.md` to use `STORAGES` instead of `STATICFILES_STORAGE`:
+
+```python
+# Before
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+# After
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
+```
+
+### Phase 5: Testing
+
+1. **Run full test suite:**
+   ```bash
+   poetry run pytest
+   ```
+
+2. **Test with demo wallet:**
+   - Start server: `python manage.py runserver --nostatic`
+   - Test at: https://demo-wallet.stellar.org
+   - Test SEP-24 deposit/withdrawal flows
+   - Verify popup detection works (historical issue area)
+
+3. **Test timezone detection:**
+   - Verify timezone middleware works
+   - Test users in different timezones
+
+4. **Test admin interface:**
+   - Verify logout works (POST method)
+   - Check form rendering
+
+---
+
+## Estimated Effort
+
+| Task | Effort | Risk |
+|------|--------|------|
+| pytz → zoneinfo migration | 2-4 hours | Medium |
+| pyproject.toml updates | 30 min | Low |
+| Documentation updates | 1 hour | Low |
+| Testing & validation | 4-8 hours | Medium |
+| **Total** | **8-14 hours** | **Medium** |
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| pytz migration breaks timezone detection | Medium | High | Comprehensive timezone tests |
+| Cross-origin issues (like Django 4.x) | Low | High | Test with demo wallet |
+| Third-party package incompatibility | Low | Medium | Check stellar-sdk, DRF compatibility |
+| Form rendering changes | Low | Low | Visual inspection of interactive flow |
+
+---
+
+## Recommendation
+
+**Upgrade to Django 5.2 LTS** with the following rationale:
+
+1. **Long-term support** - Maintained until December 2027
+2. **Python compatibility** - Works with current Python 3.10+ requirement
+3. **Stability** - Not bleeding edge, well-tested
+4. **Migration path** - Can upgrade to Django 6.x later when ready to drop Python 3.10/3.11
+
+**Do NOT upgrade to Django 6.0 yet** because:
+1. Requires Python 3.12+ (would drop 3.10/3.11 users)
+2. More breaking changes
+3. No significant features needed for Polaris
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `pyproject.toml` | Django version, remove pytz, add tzdata, update classifiers |
+| `polaris/middleware.py` | pytz → zoneinfo |
+| `polaris/sep24/tzinfo.py` | pytz → zoneinfo |
+| `polaris/sep24/utils.py` | pytz → zoneinfo |
+| `polaris/tests/sep24/test_tzinfo.py` | pytz → zoneinfo |
+| `docs/sep-24.rst` | STATICFILES_STORAGE → STORAGES |
+| `CLAUDE.md` | STATICFILES_STORAGE → STORAGES |
+| `docs/requirements.txt` | Remove pytz |
+
+---
+
+## References
+
+- [Django 5.0 Release Notes](https://docs.djangoproject.com/en/5.2/releases/5.0/)
+- [Django 5.2 Release Notes](https://docs.djangoproject.com/en/5.2/releases/5.2/)
+- [Django Deprecation Timeline](https://docs.djangoproject.com/en/dev/internals/deprecation/)
+- [Python zoneinfo documentation](https://docs.python.org/3/library/zoneinfo.html)
+- [django-upgrade tool](https://github.com/adamchainz/django-upgrade)

--- a/docs/bpv/plan-native-xlm-support.md
+++ b/docs/bpv/plan-native-xlm-support.md
@@ -1,0 +1,143 @@
+# Native XLM Support Plan
+
+## Overview
+
+Add support for native XLM as a deposit/withdrawal asset using `issuer="native"` as a sentinel value in the Asset model.
+
+## Current Limitation
+
+The `Asset` model requires an issuer field with `MinLengthValidator(56)`, which doesn't accommodate native XLM (no issuer on Stellar network).
+
+## Approach
+
+Use `issuer="native"` as a sentinel value to indicate the native Stellar asset.
+
+---
+
+## Breakage Analysis
+
+### Critical (Will Fail)
+
+#### 1. `polaris/utils.py:435` - Payment Transaction Building
+
+```python
+asset = StellarAsset(code=transaction.asset.code, issuer=transaction.asset.issuer)
+```
+
+**Problem**: Stellar SDK's `Asset()` constructor with `issuer="native"` will fail validation. For native XLM, you need `Asset.native()` instead.
+
+**Fix**:
+```python
+if transaction.asset.issuer == "native":
+    asset = StellarAsset.native()
+else:
+    asset = StellarAsset(code=transaction.asset.code, issuer=transaction.asset.issuer)
+```
+
+#### 2. `polaris/utils.py:139-152` - Trustline Check
+
+```python
+if transaction.asset.issuer == asset_issuer:  # comparing to Horizon response
+```
+
+**Problem**: Horizon API returns `asset_type: "native"` without `asset_issuer` field for XLM. This comparison will never match.
+
+**Fix**: Skip trustline check entirely for native assets (they don't need trustlines):
+```python
+def is_pending_trust(transaction, json_resp):
+    if transaction.asset.issuer == "native":
+        return False  # XLM doesn't need trustlines
+    # ... rest of logic
+```
+
+#### 3. `polaris/management/commands/watch_transactions.py:271,313,323,327` - Incoming Payment Matching
+
+```python
+payment_data["issuer"] == want_asset.issuer
+```
+
+**Problem**: When matching incoming XLM payments, `operation.asset.issuer` from SDK is `None` for native assets, not `"native"`.
+
+**Fix**: Handle native asset comparison:
+```python
+if want_asset.issuer == "native":
+    matches = payment_data["issuer"] is None and payment_data["code"] == "XLM"
+else:
+    matches = payment_data["issuer"] == want_asset.issuer
+```
+
+---
+
+### API Response Issues (Won't Crash, But Incorrect)
+
+#### 4. `polaris/sep38/info.py:19` - SEP-38 Asset Format
+
+```python
+{"asset": f"stellar:{asset.code}:{asset.issuer}"}  # Returns "stellar:XLM:native"
+```
+
+**Problem**: SEP-38 spec expects `stellar:native` for XLM, not `stellar:XLM:native`.
+
+**Fix**:
+```python
+if asset.issuer == "native":
+    info_data["assets"].append({"asset": "stellar:native"})
+else:
+    info_data["assets"].append({"asset": f"stellar:{asset.code}:{asset.issuer}"})
+```
+
+#### 5. `polaris/integrations/toml.py:37` - stellar.toml CURRENCIES
+
+```python
+{"code": asset.code, "issuer": asset.issuer}  # Returns issuer: "native"
+```
+
+**Problem**: SEP-1 stellar.toml shouldn't include `issuer` field for XLM.
+
+**Fix**: Conditionally exclude issuer for native.
+
+#### 6. `polaris/models.py:271` - Asset Identification Format
+
+```python
+return f"stellar:{self.code}:{self.issuer}"  # Returns "stellar:XLM:native"
+```
+
+**Fix**: Return `"stellar:native"` for XLM.
+
+#### 7. `polaris/models.py:784` - Transaction asset_name Property
+
+```python
+return self.asset.code + ":" + self.asset.issuer  # Returns "XLM:native"
+```
+
+Less critical but looks odd in logs/responses.
+
+---
+
+## Summary Table
+
+| Location | Severity | Issue |
+|----------|----------|-------|
+| `utils.py:435` | **CRITICAL** | SDK Asset construction fails |
+| `utils.py:139-152` | **CRITICAL** | Trustline check always fails |
+| `watch_transactions.py:271` | **CRITICAL** | Payment matching fails |
+| `sep38/info.py:19` | Medium | Wrong SEP-38 format |
+| `integrations/toml.py:37` | Medium | Invalid stellar.toml |
+| `models.py:271` | Medium | Wrong asset ID format |
+| `models.py:784` | Low | Odd display in logs |
+
+---
+
+## Implementation Checklist
+
+- [ ] Add `is_native` property to Asset model
+- [ ] Update `asset_identification_format` property in Asset model
+- [ ] Update `is_pending_trust()` in `utils.py`
+- [ ] Update `create_deposit_envelope()` in `utils.py`
+- [ ] Update `_check_for_payment_match()` in `watch_transactions.py`
+- [ ] Update `_get_payment_values()` in `watch_transactions.py`
+- [ ] Update SEP-38 info endpoint
+- [ ] Update stellar.toml integration
+- [ ] Update Transaction `asset_name` property
+- [ ] Remove or adjust issuer MinLengthValidator for "native" value
+- [ ] Add tests for native XLM deposit/withdrawal flows

--- a/docs/bpv/sep-0058-5.md
+++ b/docs/bpv/sep-0058-5.md
@@ -1,0 +1,1120 @@
+## Preamble
+
+```
+SEP: 0058
+Title: External Account API
+Author: TBD
+Status: Draft
+Created: 2026-03-19
+Updated: 2026-03-21
+Discussion: TBD
+Version 0.3.0
+```
+
+## Summary
+
+This SEP defines a standard API for wallets and other Stellar clients to
+request provisioned inbound receiving instruments from a provider.
+
+Examples include:
+
+- crypto deposit addresses (e.g. Ethereum, Base, Arbitrum)
+- virtual bank accounts (e.g. ACH virtual account, SEPA IBAN)
+- bank account credentials (e.g. CLABE, SPEI)
+
+The provisioned instrument is bound to the authenticated user's Stellar wallet
+and is intended to receive off-chain or external-network deposits that settle
+to that wallet.
+
+This SEP uses bearer authentication obtained via [SEP-10](sep-0010.md) for
+classic (G...) and muxed (M...) accounts, or [SEP-45](sep-0045.md) for
+contract (C...) accounts. Providers supporting all Stellar account types must
+implement both authentication protocols.
+
+This SEP is independent from [SEP-6](sep-0006.md) and [SEP-24](sep-0024.md).
+It provisions an account resource. It does not create a deposit transaction.
+
+## Motivation
+
+[SEP-6](sep-0006.md) already allows anchors to return deposit instructions, but
+those instructions are transaction-scoped: the wallet asks for instructions to
+complete a specific deposit flow, and the anchor returns credentials for *that*
+deposit. Many providers also need a standard way to provision reusable receiving
+instruments outside a specific deposit or withdrawal flow.
+
+This SEP standardizes that simpler object:
+
+- discover what receiving instruments a provider supports
+- request one for the authenticated user
+- poll for its status
+- retrieve the credentials needed to receive funds
+
+The design stays close to existing Stellar conventions:
+
+- discovery via [SEP-1](sep-0001.md)
+- authentication via [SEP-10](sep-0010.md) or [SEP-45](sep-0045.md)
+- credential fields via [SEP-9](sep-0009.md)
+- credential payload shape and callback signing via [SEP-6](sep-0006.md)
+- KYC remediation via [SEP-12](sep-0012.md)
+
+### Why Not Extend SEP-6?
+
+[SEP-6](sep-0006.md) models deposits as transactions. Each `GET /deposit`
+call creates a new transaction with its own `id`, `status`, and lifecycle.
+Some anchors have worked around this by returning the same deposit address
+across multiple SEP-6 transactions
+([stellar-protocol#1341](https://github.com/stellar/stellar-protocol/issues/1341)),
+but this creates ambiguity: the client expects a transaction, the anchor
+returns a reusable account, and reconciliation becomes unclear.
+
+The core difference is resource identity:
+
+| Concern | SEP-6 | SEP-58 |
+|---------|-------|--------|
+| Resource | Transaction (one-time deposit flow) | Account (reusable receiving instrument) |
+| Lifecycle | `incomplete` -> `pending_user_transfer_start` -> `completed` | `pending` -> `active` -> `deactivated` |
+| Credential scope | Bound to one transaction | Bound to one user, reusable across deposits |
+| Idempotency | Each call may create a new transaction | Same params return the same account |
+| `GET /transactions` | Lists deposit/withdrawal history | N/A -- accounts are not transactions |
+
+A SEP-6 extension
+([stellar-protocol#1372](https://github.com/stellar/stellar-protocol/issues/1372))
+could add async deposit instructions, but it would overload the transaction
+model with account semantics. SEP-58 keeps both models clean: SEP-6 for
+transactions, SEP-58 for accounts.
+
+Providers may implement both. A provider can provision an account via SEP-58
+and accept SEP-6 deposits into that same account. The `instructions` payload
+uses the same [SEP-9](sep-0009.md) field names in both protocols.
+
+If a provider needs transaction amount, quote context, flow-specific settlement
+instructions, or any other transaction-scoped input before it can determine the
+correct receiving instructions, the provider should use [SEP-6](sep-0006.md) or
+[SEP-24](sep-0024.md) instead of SEP-58.
+
+### Relationship to Stellar Account Types
+
+Stellar supports three address types that may appear as authenticated subjects
+and as settlement destinations in this SEP:
+
+- **Classic accounts (G...)** are authenticated via [SEP-10](sep-0010.md).
+  A classic account may optionally include a memo to identify a sub-account
+  within a shared Stellar account.
+
+- **Muxed accounts (M...)** are authenticated via [SEP-10](sep-0010.md).
+  A muxed account (CAP-27) encodes a 64-bit sub-account ID directly in the
+  address, solving Stellar-to-Stellar routing without on-chain memo
+  coordination. A muxed account may appear directly as the `stellar_account`
+  in a SEP-58 account object. When `stellar_account` is a muxed account,
+  `memo` must be omitted.
+
+- **Contract accounts (C...)** are authenticated via [SEP-45](sep-0045.md).
+  A contract account is a Soroban smart contract that abstracts account
+  ownership. Contract accounts are the sole authenticated subject in a SEP-45
+  session. `memo` must not be used to encode ownership or sub-identity for a
+  contract account; the contract account itself is the subject.
+
+SEP-58 solves a different problem than any of these address types:
+provisioning *off-chain* or *external-network* receiving instruments (bank
+accounts, crypto addresses on other chains) that map to a Stellar destination.
+A muxed or contract account may appear as the `stellar_account`, but neither
+can provision an ACH virtual account number or an Ethereum deposit address on
+its own.
+
+## Out of Scope
+
+This SEP does not define:
+
+- cards or card references (PCI compliance makes these a distinct problem)
+- payout instruments (this SEP is inbound-only)
+- internal provider reconciliation or settlement timing
+- [SEP-6](sep-0006.md) or [SEP-24](sep-0024.md) transaction creation
+- a global registry of payment rails
+- exchange rates or quotes (see [SEP-38](sep-0038.md))
+- client-triggered deactivation (may be added in a future version)
+- how providers validate bearer tokens internally (see [Token Validation](#token-validation))
+
+## Definitions
+
+- **Provider**: a server implementing this SEP (often an anchor, but not
+  necessarily limited to anchors)
+- **Account**: a provisioned inbound receiving instrument
+- **Offering**: a specific supported combination a client may request
+- **Authenticated subject**: the identity established by the bearer token.
+  For SEP-10, this is the classic account (G...) with optional memo semantics,
+  or the muxed account (M...). For SEP-45, this is the contract account (C...).
+
+Account kinds:
+
+- `crypto_address`: a blockchain deposit address
+- `virtual_account`: a provider-provisioned inbound account mapped to the user
+- `bank_account`: bank account credentials the provider instructs the client
+  to use
+
+## Design Principles
+
+- One resource: `account`
+- One discovery key: `EXTERNAL_ACCOUNT_SERVER`
+- One canonical credential payload: `instructions`
+- One obvious control path: authenticate, inspect offerings, create or fetch
+  account, poll status
+- Conservative reuse by default: providers should return an existing compatible
+  account when possible
+- Explicit support matrices: clients must not infer rail-country compatibility
+  from separate lists
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+    participant Wallet
+    participant Provider
+    participant User
+
+    Wallet->>+Provider: GET /.well-known/stellar.toml
+    Provider-->>-Wallet: EXTERNAL_ACCOUNT_SERVER, auth config
+
+    Wallet->>+Provider: GET /info
+    Provider-->>-Wallet: explicit offerings
+
+    alt Classic or Muxed account (G... / M...)
+        Wallet->>+Provider: GET <WEB_AUTH_ENDPOINT> (SEP-10 challenge)
+        Provider-->>-Wallet: challenge transaction
+        Wallet->>+Provider: POST <WEB_AUTH_ENDPOINT> (signed challenge)
+        Provider-->>-Wallet: JWT (sub = G... or M...)
+    else Contract account (C...)
+        Wallet->>+Provider: GET <WEB_AUTH_FOR_CONTRACTS_ENDPOINT> (SEP-45 challenge)
+        Provider-->>-Wallet: authorization entries
+        Wallet->>+Provider: POST <WEB_AUTH_FOR_CONTRACTS_ENDPOINT> (signed entries)
+        Provider-->>-Wallet: JWT (sub = C...)
+    end
+
+    Wallet->>+User: choose offering
+    User-->>-Wallet: confirm
+    Wallet->>+Provider: POST /accounts (Bearer JWT)
+    Provider-->>-Wallet: account object (pending or active)
+    Wallet->>+Provider: GET /accounts/:id (Bearer JWT)
+    Provider-->>-Wallet: updated account object
+```
+
+## Discovery
+
+Providers implementing this SEP must publish an HTTPS endpoint in
+[`stellar.toml`](sep-0001.md):
+
+```toml
+EXTERNAL_ACCOUNT_SERVER="https://api.example.com/sep58"
+```
+
+The key follows the descriptive naming convention used by other SEPs
+(`TRANSFER_SERVER` for SEP-6, `ANCHOR_QUOTE_SERVER` for SEP-38). The
+endpoint represents the root of this SEP's API.
+
+`EXTERNAL_ACCOUNT_SERVER` discovers only the SEP-58 API root. Authentication
+is discovered separately through SEP-1:
+
+- Clients authenticating classic or muxed accounts discover SEP-10 via
+  `WEB_AUTH_ENDPOINT` and `SIGNING_KEY` in `stellar.toml`.
+- Clients authenticating contract accounts must also discover SEP-45 via
+  `WEB_AUTH_FOR_CONTRACTS_ENDPOINT`, `WEB_AUTH_CONTRACT_ID`, and `SIGNING_KEY`
+  in `stellar.toml`.
+
+Providers supporting contract-account authentication must publish the SEP-45
+authentication metadata required to obtain bearer tokens for C... accounts.
+
+## Authentication
+
+This SEP uses bearer authentication obtained via [SEP-10](sep-0010.md) or
+[SEP-45](sep-0045.md):
+
+- [SEP-10](sep-0010.md) authenticates classic (G...) and muxed (M...) accounts.
+- [SEP-45](sep-0045.md) authenticates Soroban contract (C...) accounts.
+- Providers supporting all Stellar account types must implement both.
+- A provider may implement only SEP-10 or only SEP-45. If so, it should make
+  that limitation clear in documentation and discovery. Providers claiming full
+  account-type support must implement both.
+
+`GET /info` may be accessed without authentication.
+
+All other endpoints require:
+
+```
+Authorization: Bearer <jwt>
+```
+
+The bearer token may originate from either SEP-10 or SEP-45. SEP-58 does not
+distinguish between the two at the endpoint level; it consumes a valid JWT and
+relies on the issuing protocol to define how the token was minted and validated.
+SEP-58 standardizes only the identity and authorization consequences once a
+valid session exists.
+
+### Subject Binding Rules
+
+The provisioned account must be bound to the authenticated subject. The
+binding rules depend on the authentication protocol:
+
+| Auth Protocol | JWT Subject | Binding Rule |
+|---------------|-------------|--------------|
+| SEP-10 (classic) | G... | Bind to the classic account. If the JWT includes memo semantics per SEP-10, scope to that sub-identity. |
+| SEP-10 (muxed) | M... | Bind to the muxed identity. `memo` must be omitted in the account object. |
+| SEP-45 (contract) | C... | Bind to the contract account. `memo` must not be used for sub-identity; the contract account is the sole subject. |
+
+**Invariant**: `stellar_account` in the returned account object must represent
+the same bound destination identity used for provisioning. A provider must not
+return a `stellar_account` that differs from the authenticated subject's
+intended settlement destination.
+
+### Client Domain Attribution
+
+[SEP-45](sep-0045.md) supports optional `client_domain` verification and an
+optional `client_domain` JWT claim. In the context of SEP-58:
+
+- Providers may use verified `client_domain` information from a
+  SEP-45-authenticated session for policy decisions, attribution, rate
+  limiting, or analytics.
+- Lack of `client_domain` must not change account ownership semantics.
+- `client_domain` never changes the idempotency key or account owner; it is
+  metadata about the client software, not about the authenticated subject.
+- `client_domain` is not part of any SEP-58 request or response object.
+
+## Content Type
+
+All requests and responses use:
+
+- `application/json`
+
+## HTTPS Only
+
+This protocol handles the movement of value. Providers and clients must use
+HTTPS for all endpoints.
+
+## CORS
+
+Provider servers must implement
+[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) to allow
+browser-based wallets to access the API. At minimum:
+
+- `Access-Control-Allow-Origin: *` for `GET /info`
+- Appropriate `Access-Control-Allow-Origin` headers for authenticated endpoints
+
+This is consistent with the CORS expectations of
+[SEP-1](sep-0001.md) and [SEP-6](sep-0006.md).
+
+## Errors
+
+Errors should return an appropriate HTTP status code and a JSON response body.
+
+Common status codes:
+
+| Status Code | Name              | Reason                                                       |
+| ----------- | ----------------- | ------------------------------------------------------------ |
+| `400`       | Bad Request       | The request is invalid or cannot be satisfied as requested.  |
+| `403`       | Permission Denied | Authentication is required or the token is not accepted.     |
+| `404`       | Not Found         | The requested account does not exist for the authenticated user. |
+
+`403` responses include but are not limited to:
+
+- Missing bearer token.
+- Token not accepted (expired, malformed, or signature invalid).
+- SEP-10 token presented for a contract account that requires SEP-45
+  authentication, or vice versa.
+- SEP-45 token not valid for the requested contract subject.
+
+Standard error body:
+
+```json
+{
+  "error": "The requested offering is not supported."
+}
+```
+
+If additional customer information is required, providers should respond with
+`403` and a body following the non-interactive customer information pattern used
+by [SEP-6](sep-0006.md) and [SEP-12](sep-0012.md):
+
+```json
+{
+  "type": "non_interactive_customer_info_needed",
+  "fields": ["birth_date", "address"]
+}
+```
+
+Providers may also include `more_info_url` when they require an interactive
+browser-based remediation flow:
+
+```json
+{
+  "type": "non_interactive_customer_info_needed",
+  "fields": ["birth_date", "address"],
+  "more_info_url": "https://api.example.com/kyc/flow/abc123"
+}
+```
+
+KYC requirements in this SEP must be derived only from:
+
+- the authenticated subject
+- the requested offering
+
+If a provider needs transaction amount, quote context, or any other
+transaction-scoped input to determine KYC requirements, the provider should
+use [SEP-6](sep-0006.md) or [SEP-24](sep-0024.md) instead of SEP-58.
+
+## Data Formats
+
+### Country Codes
+
+`country_code` uses [ISO 3166-1 alpha-2](https://www.iso.org/iso-3166-country-codes.html)
+codes such as `US`, `MX`, and `DE`. This is consistent with the country code
+format used by [SEP-6](sep-0006.md) and [SEP-38](sep-0038.md), and aligns with
+the format used by most financial APIs (ISO 20022, SWIFT, IBAN).
+
+Note: [SEP-9](sep-0009.md) uses alpha-3 for some KYC fields. This SEP uses
+alpha-2 because it matches the convention already established by SEP-6 and
+SEP-38 for API parameters, and because alpha-2 is the dominant format in
+payment systems that providers and clients already integrate with.
+
+### Currency Codes
+
+`currency` uses [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html)
+codes such as `USD`, `MXN`, and `EUR`.
+
+### Rail
+
+`rail` is a provider-published string identifying the payment network used for
+the receiving instrument. This SEP intentionally does not define a global rail
+enum. Rails vary by region, provider capability, and regulatory context.
+
+Rail values should be uppercase, stable, and recognizable. Providers must
+publish actual supported combinations in `GET /info`.
+
+Recommended values for common rails:
+
+| Rail       | Description                          |
+| ---------- | ------------------------------------ |
+| `ACH`      | US Automated Clearing House          |
+| `SEPA`     | Single Euro Payments Area            |
+| `SPEI`     | Mexico Sistema de Pagos Electronicos |
+| `SWIFT`    | SWIFT international wire             |
+| `PIX`      | Brazil instant payment system        |
+| `FEDWIRE`  | US Fedwire Funds Service             |
+
+This table is non-normative. Providers may use other values for rails not
+listed here.
+
+### Chain Identifiers
+
+`chain_id` uses the [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) format
+(`namespace:reference`). CAIP-2 is used because SEP-58 provisions deposit
+addresses on non-Stellar chains (Ethereum, Base, Arbitrum, etc.) where no
+Stellar-native identifier exists. Providers must also include a human-readable
+`network` string so clients do not need to interpret CAIP identifiers on their
+own.
+
+Examples:
+
+| `chain_id`      | `network`             |
+| --------------- | --------------------- |
+| `eip155:1`      | Ethereum Mainnet      |
+| `eip155:10`     | Optimism              |
+| `eip155:8453`   | Base                  |
+| `eip155:56`     | BNB Smart Chain       |
+| `eip155:42161`  | Arbitrum One          |
+| `stellar:pubnet`| Stellar Mainnet       |
+
+The Stellar namespace uses the identifiers defined in
+[CAIP-28](https://chainagnostic.org/CAIPs/caip-28).
+
+### Stellar Asset Format
+
+`stellar_asset` identifies the Stellar asset credited when funds received
+through this account are settled on Stellar. The value uses the
+[SEP-11](sep-0011.md) format:
+
+- `native` for XLM
+- `Code:Issuer` for issued assets (e.g. `USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN`)
+
+### Instructions
+
+The `instructions` object reuses the credential payload shape defined by
+[SEP-6](sep-0006.md): keys are [SEP-9](sep-0009.md) financial account fields
+and values are objects with `value` and `description`.
+
+This version of the SEP supports only receiving credentials that can be
+expressed using [SEP-9](sep-0009.md) field names. Keys must use the field names
+as defined in SEP-9, including the `organization.` prefix where the
+corresponding field is defined that way.
+
+| Name          | Type   | Description                                                                                                                                                |
+| ------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`       | string | The value of the field.                                                                                                                                    |
+| `description` | string | A human-readable description of the field. This can be used to provide any additional information about fields that are not defined in the SEP-9 standard. |
+
+Example (bank payment):
+
+```json
+{
+  "organization.bank_account_number": {
+    "value": "1234567890",
+    "description": "Account number"
+  },
+  "organization.bank_number": {
+    "value": "021000021",
+    "description": "ACH routing number"
+  }
+}
+```
+
+Example (crypto address):
+
+```json
+{
+  "organization.crypto_address": {
+    "value": "0xAbCDef0123456789aBCdef0123456789abCDef01",
+    "description": "Deposit address"
+  }
+}
+```
+
+Example (crypto address with memo):
+
+```json
+{
+  "organization.crypto_address": {
+    "value": "rN7hxPaEBfhCKjQhnGriWNsFbEyR7iMRrg",
+    "description": "XRP deposit address"
+  },
+  "organization.crypto_memo": {
+    "value": "1847203",
+    "description": "Destination tag -- required"
+  }
+}
+```
+
+Example (Mexican CLABE):
+
+```json
+{
+  "organization.clabe_number": {
+    "value": "646180111803859359",
+    "description": "CLABE number"
+  }
+}
+```
+
+## Endpoints
+
+- [`GET /info`](#get-info)
+- [`POST /accounts`](#post-accounts)
+- [`GET /accounts`](#get-accounts)
+- [`GET /accounts/:id`](#get-accountsid)
+
+## GET /info
+
+This endpoint describes what the provider can provision.
+
+Providers must publish explicit offerings, not separate lists of countries,
+currencies, and rails. Clients should never have to guess whether a rail
+applies to a country or currency.
+
+### Authentication
+
+Optional.
+
+### Request
+
+No request arguments are required.
+
+### Response
+
+A successful response returns `200 OK`.
+
+| Name        | Type  | Description |
+| ----------- | ----- | ----------- |
+| `offerings` | array | A list of explicit supported offerings. |
+
+Offering fields vary by `kind`.
+
+Common offering fields:
+
+| Name           | Type   | Description |
+| -------------- | ------ | ----------- |
+| `kind`         | string | One of `crypto_address`, `virtual_account`, or `bank_account`. |
+| `country_code` | string | Required for `virtual_account` and `bank_account`. ISO 3166-1 alpha-2. |
+| `currency`     | string | Required for `virtual_account` and `bank_account`. ISO 4217. |
+| `rail`         | string | Required for `virtual_account` and `bank_account`. |
+| `chain_id`     | string | Required for `crypto_address`. CAIP-2 identifier. |
+| `network`      | string | Required for `crypto_address`. Human-readable network name. |
+
+Providers may include additional provider-specific fields in each offering
+object (e.g. `description`, `min_deposit`, `max_deposit`). Clients should
+ignore fields they do not recognize.
+
+Example:
+
+```json
+{
+  "offerings": [
+    {
+      "kind": "virtual_account",
+      "country_code": "US",
+      "currency": "USD",
+      "rail": "ACH"
+    },
+    {
+      "kind": "virtual_account",
+      "country_code": "DE",
+      "currency": "EUR",
+      "rail": "SEPA"
+    },
+    {
+      "kind": "bank_account",
+      "country_code": "MX",
+      "currency": "MXN",
+      "rail": "SPEI"
+    },
+    {
+      "kind": "crypto_address",
+      "chain_id": "eip155:1",
+      "network": "Ethereum Mainnet"
+    },
+    {
+      "kind": "crypto_address",
+      "chain_id": "eip155:8453",
+      "network": "Base"
+    }
+  ]
+}
+```
+
+## POST /accounts
+
+This endpoint creates or returns a provisioned account for the authenticated
+user.
+
+Providers should be conservative with account creation. If a compatible account
+already exists in `active` status, the provider should return that account
+instead of creating a new one. If a compatible account exists in `pending`
+status, the provider may return that pending account instead of creating a
+duplicate provisioning request.
+
+Accounts in `deactivated` or `error` status must not satisfy a new
+provisioning request. The provider must create a new account or return another
+compatible account in `active` or `pending` status.
+
+The client can detect whether a new account was created by inspecting the HTTP
+status code (`200` vs `201`).
+
+### Authentication
+
+Required. The bearer token may be obtained via [SEP-10](sep-0010.md) for
+G.../M... accounts or [SEP-45](sep-0045.md) for C... accounts.
+
+### Request
+
+The request must include `kind`.
+
+For `virtual_account` and `bank_account`, the request must include:
+
+- `country_code`
+- `currency`
+
+`rail` is optional. If omitted, the provider may choose a compatible rail but
+must return the resolved `rail` in the response.
+
+For `crypto_address`, the request must include:
+
+- `chain_id`
+
+Optional request fields:
+
+| Name                 | Type   | Description |
+| -------------------- | ------ | ----------- |
+| `on_change_callback` | string | An HTTPS callback URL for account status changes. See [Webhooks](#webhooks). |
+
+`on_change_callback` must be an HTTPS URL. Providers should reject non-HTTPS
+callback URLs with a `400` response. This is consistent with the HTTPS
+requirement for callback URLs in [SEP-6](sep-0006.md).
+
+If `on_change_callback` is provided and the provider does not support webhooks,
+the provider should ignore the field rather than reject the request.
+
+Request examples:
+
+```json
+{
+  "kind": "virtual_account",
+  "country_code": "US",
+  "currency": "USD"
+}
+```
+
+```json
+{
+  "kind": "bank_account",
+  "country_code": "MX",
+  "currency": "MXN",
+  "rail": "SPEI"
+}
+```
+
+```json
+{
+  "kind": "crypto_address",
+  "chain_id": "eip155:1"
+}
+```
+
+### Response
+
+If a new account is created, providers should return `201 Created`.
+
+If an existing compatible account is returned, providers should return
+`200 OK`.
+
+The response body is wrapped in an `account` key:
+
+```json
+{
+  "account": { ... }
+}
+```
+
+See [Account Object](#account-object) for the full schema.
+
+## GET /accounts
+
+This endpoint lists accounts belonging to the authenticated user.
+
+### Authentication
+
+Required. The bearer token may be obtained via [SEP-10](sep-0010.md) for
+G.../M... accounts or [SEP-45](sep-0045.md) for C... accounts.
+
+### Request
+
+Optional query parameter filters:
+
+| Name           | Type   | Description |
+| -------------- | ------ | ----------- |
+| `kind`         | string | Filter by account kind. |
+| `country_code` | string | Filter by country code. |
+| `status`       | string | Filter by status. |
+
+Example:
+
+```
+GET /accounts?kind=virtual_account&country_code=US
+```
+
+Pagination is not defined in this version. Providers serving users with many
+accounts should return a reasonable default limit. A future version of this SEP
+may standardize cursor-based pagination.
+
+### Response
+
+A successful response returns `200 OK`.
+
+```json
+{
+  "accounts": [
+    {
+      "id": "acc_123",
+      "kind": "virtual_account",
+      "status": "active",
+      "country_code": "US",
+      "currency": "USD",
+      "rail": "ACH",
+      "stellar_asset": "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      "stellar_account": "GABCD...",
+      "memo": "123456789",
+      "memo_type": "id",
+      "instructions": {
+        "organization.bank_account_number": {
+          "value": "1234567890",
+          "description": "Account number"
+        },
+        "organization.bank_number": {
+          "value": "021000021",
+          "description": "ACH routing number"
+        }
+      },
+      "more_info_url": "https://api.example.com/accounts/acc_123",
+      "created_at": "2026-03-19T10:00:00Z",
+      "updated_at": "2026-03-19T10:00:00Z"
+    }
+  ]
+}
+```
+
+## GET /accounts/:id
+
+This endpoint returns a single account object for the authenticated user.
+
+It is the primary polling endpoint for checking provisioning progress and
+retrieving the final active credentials.
+
+### Authentication
+
+Required. The bearer token may be obtained via [SEP-10](sep-0010.md) for
+G.../M... accounts or [SEP-45](sep-0045.md) for C... accounts.
+
+### Request
+
+No request body is required.
+
+### Response
+
+A successful response returns `200 OK`.
+
+Example `virtual_account` response (SEP-10 classic account):
+
+```json
+{
+  "account": {
+    "id": "acc_123",
+    "kind": "virtual_account",
+    "status": "active",
+    "country_code": "US",
+    "currency": "USD",
+    "rail": "ACH",
+    "stellar_asset": "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    "stellar_account": "GABCD...",
+    "memo": "123456789",
+    "memo_type": "id",
+    "instructions": {
+      "organization.bank_account_number": {
+        "value": "1234567890",
+        "description": "Account number"
+      },
+      "organization.bank_number": {
+        "value": "021000021",
+        "description": "ACH routing number"
+      }
+    },
+    "more_info_url": "https://api.example.com/accounts/acc_123",
+    "created_at": "2026-03-19T10:00:00Z",
+    "updated_at": "2026-03-19T10:00:00Z"
+  }
+}
+```
+
+Example `crypto_address` response (SEP-10 classic account):
+
+```json
+{
+  "account": {
+    "id": "acc_456",
+    "kind": "crypto_address",
+    "status": "active",
+    "chain_id": "eip155:1",
+    "network": "Ethereum Mainnet",
+    "stellar_asset": "native",
+    "stellar_account": "GABCD...",
+    "memo": "123456789",
+    "memo_type": "id",
+    "instructions": {
+      "organization.crypto_address": {
+        "value": "0xAbCDef0123456789aBCdef0123456789abCDef01",
+        "description": "Deposit address"
+      }
+    },
+    "more_info_url": "https://api.example.com/accounts/acc_456",
+    "created_at": "2026-03-19T10:00:00Z",
+    "updated_at": "2026-03-19T10:00:00Z"
+  }
+}
+```
+
+Example `crypto_address` response (SEP-45 contract account):
+
+```json
+{
+  "account": {
+    "id": "acc_789",
+    "kind": "crypto_address",
+    "status": "active",
+    "chain_id": "eip155:8453",
+    "network": "Base",
+    "stellar_asset": "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    "stellar_account": "CCLHBURYO4B2JFU4YBZUQZKJQ2Z3723DPXTWU6YDPXN4TZ3KHVQ7NOUL",
+    "instructions": {
+      "organization.crypto_address": {
+        "value": "0x9876543210AbCdEf9876543210aBcDeF98765432",
+        "description": "Base deposit address"
+      }
+    },
+    "more_info_url": "https://api.example.com/accounts/acc_789",
+    "created_at": "2026-03-21T14:00:00Z",
+    "updated_at": "2026-03-21T14:00:00Z"
+  }
+}
+```
+
+Note: The contract account example omits `memo` and `memo_type` because the
+contract account (C...) is the sole authenticated subject. Sub-identity via
+memo does not apply to contract accounts.
+
+## Account Object
+
+The `account` object is intentionally small. Providers should include only the
+fields needed for the chosen kind plus the common lifecycle fields below.
+
+### Common Fields
+
+| Name              | Type   | Required | Description |
+| ----------------- | ------ | -------- | ----------- |
+| `id`              | string | Yes      | Stable provider identifier for the account. |
+| `kind`            | string | Yes      | One of `crypto_address`, `virtual_account`, or `bank_account`. |
+| `status`          | string | Yes      | One of `pending`, `active`, `deactivated`, or `error`. |
+| `stellar_asset`   | string | Yes      | The Stellar asset credited when funds are settled. Uses [SEP-11](sep-0011.md) format: `native` for XLM, `Code:Issuer` for issued assets. |
+| `stellar_account` | string | Yes      | The Stellar destination identity bound to this external account. For SEP-10 sessions this is the authenticated classic (G...) or muxed (M...) destination per SEP-10 semantics. For SEP-45 sessions this is the authenticated contract account (C...). |
+| `memo`            | string | No       | Memo used with the bound Stellar destination. Omit when `stellar_account` is a muxed account (M...). Omit when `stellar_account` is a contract account (C...) authenticated via SEP-45. `memo` must not be used to encode ownership or sub-identity for a contract account. |
+| `memo_type`       | string | No       | One of `text`, `id`, or `hash`. Required when `memo` is present. |
+| `instructions`    | object | No       | Credential payload using [SEP-9](sep-0009.md) financial account fields. Present when `status` is `active`. |
+| `more_info_url`   | string | No       | URL for additional information or remediation. |
+| `created_at`      | string | Yes      | ISO 8601 timestamp. |
+| `updated_at`      | string | Yes      | ISO 8601 timestamp. |
+| `message`         | string | No       | Human-readable message, useful when `status` is `pending` or `error`. |
+
+### Additional Fields for `virtual_account` and `bank_account`
+
+| Name           | Type   | Required | Description |
+| -------------- | ------ | -------- | ----------- |
+| `country_code` | string | Yes      | ISO 3166-1 alpha-2 country code. |
+| `currency`     | string | Yes      | ISO 4217 currency code. |
+| `rail`         | string | Yes      | Payment rail used for this account. |
+
+### Additional Fields for `crypto_address`
+
+| Name       | Type   | Required | Description |
+| ---------- | ------ | -------- | ----------- |
+| `chain_id` | string | Yes      | CAIP-2 chain identifier. |
+| `network`  | string | Yes      | Human-readable network name. |
+
+### Status Semantics
+
+| Status        | Meaning |
+| ------------- | ------- |
+| `pending`     | The provider has accepted the request but the account is not yet ready to receive funds. The client should poll `GET /accounts/:id`. |
+| `active`      | The account is provisioned and ready to receive funds. `instructions` must be present. |
+| `deactivated` | The account should no longer be used for new deposits. Previously received funds are not affected. |
+| `error`       | The provider could not provision or maintain the account. Check `message` for details. |
+
+Providers must not expose usable receiving credentials before the account is
+ready. `instructions` must be present only when `status` is `active`.
+
+### Status Transitions
+
+```
+pending -> active
+pending -> error
+active -> deactivated
+active -> error
+```
+
+`deactivated` and `error` are terminal. Once an account reaches either status,
+it must not transition back to `active` or `pending`. If the client needs a new
+account, it must create one via `POST /accounts`.
+
+This SEP does not define a client-triggered deactivation endpoint.
+Providers may transition an account to `deactivated` due to internal policy,
+compliance, or user action handled outside this SEP.
+
+## Webhooks
+
+Polling via `GET /accounts/:id` is the primary interoperability path.
+
+Providers may optionally support webhooks for account status changes. If they
+do:
+
+1. The client provides `on_change_callback` in the `POST /accounts` request.
+2. The provider sends an HTTP POST to the callback URL when the account status
+   changes.
+3. The callback body should contain the same account object as returned by
+   `GET /accounts/:id`.
+
+If a provider does not support webhooks, it should ignore
+`on_change_callback` rather than reject the request.
+
+### Callback Signatures
+
+Providers supporting webhooks must sign callback requests using the signature
+scheme defined by [SEP-6](sep-0006.md):
+
+- Include a `Signature` header with format: `t=<timestamp>, s=<base64 signature>`
+- Sign the payload `<timestamp>.<wallet_host>.<body>` using the provider's
+  Stellar private key corresponding to the `SIGNING_KEY` in their
+  [`stellar.toml`](sep-0001.md).
+
+Wallets receiving callbacks must:
+
+- Verify the signature against the provider's `SIGNING_KEY`.
+- Verify freshness by comparing the timestamp to the current time (reject
+  requests older than 2 minutes).
+
+## Security Considerations
+
+- Providers must bind each account to the authenticated subject. When a
+  memo or muxed account is present in a SEP-10 JWT, the account must be scoped
+  to that specific sub-identity. When a contract account is present in a
+  SEP-45 JWT, the contract account is the sole subject.
+- Providers must treat a SEP-45-authenticated contract account as the sole
+  authenticated subject for ownership and idempotency purposes. Providers must
+  not conflate a contract account with any backing classic account that may
+  participate in Soroban authorization.
+- Providers must not infer memo-based sub-identity semantics for
+  contract-account sessions. The contract account itself is the subject.
+- If `client_domain` is present in a SEP-45 JWT, it is attribution metadata
+  only and must not change account ownership, idempotency, or binding.
+- Clients must not assume a rail applies to a country or currency unless that
+  exact combination appears in `GET /info`.
+- Providers must return only the fields necessary to receive funds.
+- Providers must not expose receiving credentials before the account is ready
+  (`instructions` only when `status` is `active`).
+- Providers must not expose internal settlement details unless required for
+  user operation.
+- Providers must use HTTPS for all endpoints and callback URLs.
+- Callback signatures prevent replay and relay attacks. Providers must not send
+  callbacks to non-HTTPS URLs.
+
+## Implementation Notes
+
+### Conservative Reuse
+
+Providers are encouraged to return existing compatible accounts rather than
+creating new ones on each `POST /accounts` request. This simplifies
+reconciliation for both providers and clients.
+
+Only accounts in `active` or `pending` status are eligible for reuse. Accounts
+in `deactivated` or `error` status must not be returned for a new provisioning
+request.
+
+The client can distinguish between a newly created account (`201`) and a reused
+one (`200`).
+
+### SEP-6 Interoperability
+
+This SEP is intentionally independent from SEP-6. However, a provider may
+choose to use the same underlying account for both SEP-58 provisioning and
+SEP-6 deposit flows. In that case, the provider should ensure that the
+`instructions` returned by both protocols are consistent.
+
+### Idempotency
+
+Providers should treat `POST /accounts` as naturally idempotent for the same
+authenticated subject and offering parameters. If the client sends the same
+request twice, the provider should return the same account rather than creating
+a duplicate.
+
+The idempotency key is the combination of the authenticated subject and the
+fields that define the offering:
+
+- For `virtual_account` and `bank_account`: `(authenticated_subject, kind, country_code, currency, rail)`
+- For `crypto_address`: `(authenticated_subject, kind, chain_id)`
+
+The authenticated subject is defined as:
+
+- **SEP-10 classic session**: the classic account (G...) plus any SEP-10
+  sub-identity semantics (memo) if applicable.
+- **SEP-10 muxed session**: the muxed identity (M...).
+- **SEP-45 session**: the contract account (C...).
+
+If `rail` is omitted, the provider should treat the resolved rail as part of the
+key — a request without `rail` that resolves to ACH should return the same
+account as a subsequent request explicitly specifying `rail: "ACH"`.
+
+### KYC Integration
+
+If a provider requires KYC information before provisioning, the recommended
+flow is:
+
+1. Client calls `POST /accounts`.
+2. Provider returns `403` with `type: "non_interactive_customer_info_needed"`
+   and the required `fields`.
+3. Client submits KYC information via [SEP-12](sep-0012.md).
+4. Client retries `POST /accounts`.
+
+KYC requirements must be derivable from the authenticated subject (obtained
+via SEP-10 or SEP-45) and the requested offering alone. For
+SEP-45-authenticated sessions, the subject is the contract account identified
+by the JWT's `sub` claim. If the provider requires transaction-scoped context
+to determine KYC needs, it should use [SEP-6](sep-0006.md) or
+[SEP-24](sep-0024.md).
+
+### Token Validation
+
+SEP-58 consumes a bearer token and relies on [SEP-10](sep-0010.md) or
+[SEP-45](sep-0045.md) to define how that token was minted and validated.
+This SEP does not standardize how providers validate bearer tokens internally.
+It standardizes only the identity and authorization consequences once a valid
+session exists.
+
+### Partial Auth Support
+
+A provider may implement only [SEP-10](sep-0010.md) or only
+[SEP-45](sep-0045.md). If so, the provider should make that limitation clear
+in its documentation and `stellar.toml` discovery metadata. Providers claiming
+full Stellar account-type support must implement both protocols.
+
+### Adoption Context
+
+This SEP addresses a gap observed in production anchor deployments. Providers
+such as Bridge (liquidation addresses), MoneyGram Access (deposit account
+provisioning), and on-chain ramp providers already offer reusable receiving
+instruments but use proprietary APIs. SEP-58 standardizes the common pattern
+so that wallets can integrate with multiple providers through a single
+interface.
+
+## Changelog
+
+- `v0.3.0`: Add normative SEP-45 support throughout. Replace "Relationship to
+  Muxed Accounts" with "Relationship to Stellar Account Types" covering G...,
+  M..., and C... addresses. Add Subject Binding Rules table defining how each
+  auth protocol maps to account ownership. Add Client Domain Attribution
+  subsection. Expand sequence diagram to show SEP-10/SEP-45 auth branches.
+  Expand Discovery section with SEP-45 prerequisite metadata
+  (`WEB_AUTH_FOR_CONTRACTS_ENDPOINT`, `WEB_AUTH_CONTRACT_ID`, `SIGNING_KEY`).
+  Add auth-mismatch 403 cases to Errors section. Update `stellar_account` field
+  definition with binding semantics per auth protocol. Tighten `memo` /
+  `memo_type` rules: must omit for muxed and contract accounts. Add C...
+  contract-account example response. Replace `user` with `authenticated_subject`
+  in Idempotency section with per-protocol definitions. Expand Security
+  Considerations with contract-account-specific rules. Add Token Validation and
+  Partial Auth Support implementation notes. Expand KYC Integration to reference
+  both auth protocols. Define `authenticated_subject` term in Definitions. Add
+  explicit auth-protocol description to each endpoint's Authentication
+  subsection.
+- `v0.2.2`: Define explicit idempotency key per kind. Require HTTPS for
+  `on_change_callback` URLs, consistent with SEP-6 callback conventions.
+- `v0.2.1`: Tighten reuse semantics -- only `active`/`pending` accounts are
+  eligible for reuse, `deactivated`/`error` are terminal and must not satisfy
+  new requests. Add pending-account reuse clause. Add webhook
+  ignore-if-unsupported fallback. Add KYC scope constraint (only authenticated
+  subject + offering). Add SEP-6 boundary sentence to "Why Not Extend SEP-6?"
+  section. Add v1 instructions scoping to SEP-9 field names. Remove `PATCH`
+  endpoint and `label` field (convenience, not interop). Use canonical
+  `organization.` prefix in all instruction examples. Strengthen "should" to
+  "must" where behavior is required for interoperability.
+- `v0.2.0`: Add "Why Not Extend SEP-6?" and "Relationship to Muxed Accounts"
+  sections addressing community review feedback. Rename discovery key from
+  `SEP58_EXTERNAL_ACCOUNT_SERVER` to `EXTERNAL_ACCOUNT_SERVER` following
+  established naming conventions. Add recommended rail values table with
+  uppercase normalization guidance. Add CAIP-2 justification. Add alpha-2 vs
+  alpha-3 rationale note. Frame PATCH deactivation scope. Add adoption context.
+- `v0.1.0`: Initial draft.
+
+## References
+
+- [SEP-1: stellar.toml](sep-0001.md)
+- [SEP-6: Deposit and Withdrawal API](sep-0006.md)
+- [SEP-9: Standard KYC Fields](sep-0009.md)
+- [SEP-10: Stellar Web Authentication](sep-0010.md)
+- [SEP-11: Txrep -- Human-readable Stellar Transactions](sep-0011.md)
+- [SEP-12: KYC API](sep-0012.md)
+- [SEP-24: Hosted Deposit and Withdrawal](sep-0024.md)
+- [SEP-38: Anchor RFQ API](sep-0038.md)
+- [SEP-45: Stellar Web Authentication for Contract Accounts](sep-0045.md)
+- [CAIP-2: Blockchain ID Specification](https://chainagnostic.org/CAIPs/caip-2)
+- [CAIP-28: Blockchain Reference for Stellar](https://chainagnostic.org/CAIPs/caip-28)
+- [ISO 3166-1 Country Codes](https://www.iso.org/iso-3166-country-codes.html)
+- [ISO 4217 Currency Codes](https://www.iso.org/iso-4217-currency-codes.html)

--- a/docs/sep-45.rst
+++ b/docs/sep-45.rst
@@ -1,0 +1,772 @@
+taken from
+https://raw.githubusercontent.com/stellar/stellar-protocol/refs/heads/master/ecosystem/sep-0045.md
+
+Preamble
+--------
+
+::
+
+   SEP: 0045
+   Title: Stellar Web Authentication for Contract Accounts
+   Author: Philip Liu <@philipliu>, Marcelo Salloum <@marcelosalloum>, Leigh McCulloch <@leighmcculloch>
+   Status: Draft
+   Created: 2024-10-08
+   Updated: 2025-12-16
+   Version: 0.1.1
+   Discussion: https://github.com/stellar/stellar-protocol/discussions/1620
+
+Simple Summary
+--------------
+
+This SEP defines the standard way for clients such as wallets or
+exchanges to create authenticated web sessions on behalf of a user who
+holds a contract account. A wallet may want to authenticate with any web
+service which requires a contract account ownership verification, for
+example, to upload KYC information to an anchor in an authenticated way
+as described in `SEP-12 <sep-0012.md>`__.
+
+This SEP is based on `SEP-10 <sep-0010.md>`__, but does not replace it.
+This SEP only supports ``C`` (contract) accounts. SEP-10 only supports
+``G`` and ``M`` accounts. Services wishing to support all accounts
+should implement both SEPs.
+
+Definitions
+-----------
+
+- **Address**: An identifier representing a possible account on the
+  Stellar network. Addresses begin with specific prefixes like G for
+  public keys (accounts controlled by secret keys), M for muxed accounts
+  and C for contract accounts.
+- **Account**: A stateful entity on the Stellar network that can hold
+  balances. This can refer to a Stellar account (``G...`` address, or
+  the ``G...`` base address of an ``M...`` address) or Soroban contract
+  that abstracts an account (``C...`` addresses).
+
+Abstract
+--------
+
+This protocol is a variation of mutual challenge-response, which uses
+Stellar authorization entries to encode challenges and responses.
+
+It involves the following components:
+
+- A **Home Domain**: a domain hosting a `SEP-1
+  stellar.toml <sep-0001.md>`__ containing a
+  ``WEB_AUTH_FOR_CONTRACTS_ENDPOINT`` (URL), ``WEB_AUTH_CONTRACT_ID``,
+  and ``SIGNING_KEY`` (``G...``).
+- A **Server**: a server providing the
+  ``WEB_AUTH_FOR_CONTRACTS_ENDPOINT`` that implements the GET and POST
+  operations discussed in this document. The server’s domain may be the
+  **Home Domain**, a sub-domain of the **Home Domain**, or a different
+  domain.
+
+  - The ``SIGNING_KEY`` from this domain is referred to as the **Server
+    Account** in this document.
+
+- A **Client Account**: the account being authenticated.
+
+  - A Stellar contract account (``C...``).
+
+- A **Client**: the software used by the holder of the **Client
+  Account** being authenticated by the **Server**.
+- A **Client Domain** (optional): a domain hosting a `SEP-1
+  stellar.toml <sep-0001.md>`__ containing a ``SIGNING_KEY`` used for
+  `Verifying the Client Domain <#verifying-the-client-domain>`__
+
+  - The ``SIGNING_KEY`` from this domain is referred to as the **Client
+    Domain Account** in this document.
+
+- A **Web Auth Contract**: a contract that implements the
+  ``web_auth_verify`` function as described in this document. The
+  contract must be deployed at the ``WEB_AUTH_CONTRACT_ID`` address
+  specified in the **Server**\ ’s ``stellar.toml``.
+
+The discovery flow is as follows:
+
+1. The **Client** retrieves the ``stellar.toml`` from the **Home
+   Domain** in accordance with `SEP-1 stellar.toml <sep-0001.md>`__.
+2. The **Client** looks up the ``WEB_AUTH_FOR_CONTRACTS_ENDPOINT``,
+   ``WEB_AUTH_CONTRACT_ID`` and ``SIGNING_KEY`` (i.e. **Server
+   Account**) from the ``stellar.toml``.
+
+The authentication flow is as follows:
+
+1.  The **Client** requests a unique ```challenge`` <#challenge>`__ from
+    the **Server** which includes a list of authorization entries
+    XDR-encoded strings
+2.  If the request contains a ``client_domain`` parameter, the
+    **Server** may fetch the **Client Domain Account** and generate the
+    challenge with an additional authorization entry as described in the
+    `Response <#response>`__ section.
+3.  The **Server** responds with the challenge
+4.  The **Client** verifies that each authorization entry does not
+    contain any sub-invocations
+5.  The **Client** verifies that the ``contract_address`` in each
+    authorization entry matches the ``WEB_AUTH_CONTRACT_ID`` from the
+    **Server**\ ’s ``stellar.toml``
+6.  The **Client** verifies that the ``function_name`` in each
+    authorization entry is ``web_auth_verify``
+7.  The **Client** verifies that the ``args`` map in each authorization
+    entry match the expected values and is the same across all
+    authorization entries:
+
+    1. The ``account`` value matches the **Client Account** address
+    2. The ``home_domain`` value matches the **Home Domain**
+    3. The ``web_auth_domain`` value matches the **Server**\ ’s domain
+    4. The ``web_auth_domain_account`` value matches the **Server
+       Account**
+    5. If the **Client** included a ``client_domain`` in the request:
+
+       1. The ``client_domain`` value matches the **Client**\ ’s domain
+       2. The ``client_domain_account`` value matches the **Client
+          Domain Account**
+
+8.  The **Client** verifies that there is an authorization entry where
+    ``credentials.address.address`` is the **Server Account** and
+    contains a valid signature from the **Server Account**
+9.  The **Client** signs the authorization entry where
+    ``credentials.address.address`` is the **Client Account** using the
+    secret key(s) of the signer(s) for the **Client Account**
+
+    - Note: **Client** signatures may not be required if the **Client**
+      contract’s ``__check_auth`` implementation does not require them
+
+10. The **Client** obtains a signature from the **Client Domain
+    Account** for the authorization entry where
+    ``credentials.address.address`` is the **Client Domain Account** if
+    the **Client** included a client domain in the request
+11. The **Client** simulates the transaction with the signed
+    authorization entries and verifies the following to ensure the
+    transaction does not have any unintended side effects:
+
+    - The transaction’s ledger footprint ``read_write`` set contains
+      only ``contract_data`` entries where:
+
+      - The ``contract`` is the **Client Account** address, and the
+        ``key`` is ``ledger_key_nonce``.
+      - The ``contract`` is the **Server Account**, and the ``key`` is
+        ``ledger_key_nonce``.
+      - (Optional) if an authorization entry for the **Client Domain
+        Account** was present in the challenge, the ``contract`` is the
+        **Client Domain Account**, and the ``key`` is
+        ``ledger_key_nonce``.
+      - (Optional) The ``contract`` is the ``WEB_AUTH_CONTRACT_ID``, and
+        the ``key`` is ``ledger_key_contract_instance`` if the web
+        authentication contract instance has been archived.
+
+12. The **Client** submits the signed authorization entries back to the
+    **Server** using ```token`` <#token>`__ endpoint
+13. The **Server** extracts the arguments from the authorization entries
+    returned by the client
+14. The **Server** verifies that the ``contract_address`` in each
+    authorization entry matches the ``WEB_AUTH_CONTRACT_ID`` from the
+    **Server**\ ’s ``stellar.toml``
+15. The **Server** verifies that the ``function_name`` in each
+    authorization entry is ``web_auth_verify``
+16. The **Server** verifies that the ``args`` map in each authorization
+    entry match the expected values and are the same across all
+    authorization entries:
+
+    1. The ``account`` value matches the **Client Account** address
+    2. The ``home_domain`` value matches the **Home Domain**
+    3. The ``web_auth_domain`` value matches the **Server**\ ’s domain
+    4. The ``web_auth_domain_account`` value matches the **Server
+       Account**
+    5. The ``client_domain_account`` value matches the **Client Domain
+       Account** if the **Client** included a ``client_domain`` in the
+       request, otherwise it is not present
+
+17. The **Server** verifies that the ``nonce`` argument is the same
+    across all authorization entries and is unique
+18. The **Server** verifies that there is an authorization entry where
+    ``credentials.address.address`` is the **Server Account** and
+    contains a valid signature from the **Server Account**
+19. The **Server** verifies that there is an authorization entry where
+    ``credentials.address.address`` is the **Client Account** address
+20. The **Server** verifies that there is an authorization entry where
+    ``credentials.address.address`` is the **Client Domain Address** if
+    the arguments included a ``client_domain_address``
+21. The **Server** constructs a transaction with a single Invoke Host
+    Function operation where the contract address is
+    ``WEB_AUTH_CONTRACT_ID`` and the function is ``web_auth_verify``
+    using the previously extracted arguments and the authorization
+    entries returned by the client
+22. If the simulation succeeds, the **Server** responds with a
+    `JWT <https://jwt.io>`__ that represents the authenticated session
+
+The flow achieves several things:
+
+- Both **Client** and **Server** can be implemented using
+  well-established Stellar libraries
+- The **Client** can verify that the **Server** holds the secret key to
+  the **Server Account**
+- The **Server** can verify that the **Client** is authorized by the
+  contract account to create an authenticated session
+- The **Server** can choose its own timeout for the authenticated
+  session
+- The **Server** can choose to include other application-specific claims
+
+Authentication Endpoint
+-----------------------
+
+The organization with a **Home Domain** indicates that it supports
+authentication via this protocol by specifying
+``WEB_AUTH_FOR_CONTRACTS_ENDPOINT`` in their
+```stellar.toml`` <sep-0001.md>`__ file. This is how a wallet knows
+where to find the **Server**. A **Server** is required to implement the
+following behavior for the web authentication endpoint:
+
+- ```GET <WEB_AUTH_FOR_CONTRACTS_ENDPOINT>`` <#challenge>`__: request a
+  challenge (step 1)
+- ```POST <WEB_AUTH_FOR_CONTRACTS_ENDPOINT>`` <#token>`__: exchange a
+  signed challenge for session JWT (step 2)
+
+Cross-Origin Headers
+--------------------
+
+Valid CORS headers are necessary to allow web clients from other sites
+to use the endpoints. The following HTTP header must be set for all
+authentication endpoints, including error responses.
+
+::
+
+   Access-Control-Allow-Origin: *
+
+In order for browsers-based wallets to validate the CORS headers, as
+`specified by W3C <https://www.w3.org/TR/cors/#preflight-request>`__,
+the preflight request (OPTIONS request) must be implemented in all the
+endpoints that support Cross-Origin.
+
+Challenge
+~~~~~~~~~
+
+This endpoint must respond with authorization entries to be signed by
+the **Client**. The **Client** signs the entries using standard Stellar
+libraries and submit it to ```token`` <#token>`__ endpoint to prove that
+it controls the **Client Account**. This approach is compatible with
+hardware wallets such as Ledger. The **Client Application** must also
+verify the server’s signature to be sure the challenge is signed by the
+**Server Account**, that the home domain argument in the function
+invocation is the **Home Domain**, and that the web auth domain argument
+in the function invocation is the **Server** domain.
+
+Request
+^^^^^^^
+
+::
+
+   GET <WEB_AUTH_FOR_CONTRACTS_ENDPOINT>
+
+Request Parameters:
+'''''''''''''''''''
+
++---+---+------------------------------------------------------------------+
+| N | T | Description                                                      |
+| a | y |                                                                  |
+| m | p |                                                                  |
+| e | e |                                                                  |
++===+===+==================================================================+
+| ` | ` | The **Client Account** address (``C...``) that the **Client**    |
+| ` | ` | wishes to authenticate with the **Server**.                      |
+| a | C |                                                                  |
+| c | . |                                                                  |
+| c | . |                                                                  |
+| o | . |                                                                  |
+| u | ` |                                                                  |
+| n | ` |                                                                  |
+| t | s |                                                                  |
+| ` | t |                                                                  |
+| ` | r |                                                                  |
+|   | i |                                                                  |
+|   | n |                                                                  |
+|   | g |                                                                  |
++---+---+------------------------------------------------------------------+
+| ` | s | A **Home Domain**. Servers that generate tokens for multiple     |
+| ` | t | **Home Domain**\ s can use this parameter to identify which home |
+| h | r | domain the **Client** hopes to authenticate with.                |
+| o | i |                                                                  |
+| m | n |                                                                  |
+| e | g |                                                                  |
+| _ |   |                                                                  |
+| d |   |                                                                  |
+| o |   |                                                                  |
+| m |   |                                                                  |
+| a |   |                                                                  |
+| i |   |                                                                  |
+| n |   |                                                                  |
+| ` |   |                                                                  |
+| ` |   |                                                                  |
++---+---+------------------------------------------------------------------+
+| ` | s | (optional) a **Client Domain**. Supplied by **Clients** that     |
+| ` | t | intend to verify their domain in addition to the **Client        |
+| c | r | Account**. See `Verifying the Client                             |
+| l | i | Domain <#verifying-the-client-domain>`__. **Servers** should     |
+| i | n | ignore this parameter if the **Server** does not support         |
+| e | g | **Client Domain** verification, or the **Server** does not       |
+| n |   | support verification for the specific **Client Domain** included |
+| t |   | in the request.                                                  |
+| _ |   |                                                                  |
+| d |   |                                                                  |
+| o |   |                                                                  |
+| m |   |                                                                  |
+| a |   |                                                                  |
+| i |   |                                                                  |
+| n |   |                                                                  |
+| ` |   |                                                                  |
+| ` |   |                                                                  |
++---+---+------------------------------------------------------------------+
+
+Example:
+
+::
+
+   GET https://auth.example.com/?account=CCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ&home_domain=example.com
+
+Response
+^^^^^^^^
+
+Success
+'''''''
+
+On success the endpoint must return ``200 OK`` HTTP status code and a
+JSON object with the following fields:
+
+- ``authorization_entries``: XDR-encoded
+  ``SorobanAuthorizationEntries``. It contains an entry for the **Client
+  Account** in addition to a signed entry from the **Server Account**
+  and optionally the **Client Domain Account**. The entries are not
+  guaranteed to be in any specific order.
+
+Each entry’s ``root_invocation`` function is a ``contract_fn`` with no
+sub-invocations and the following values:
+
+- ``contract_address`` is the ``WEB_AUTH_CONTRACT_ID`` from the
+  **Server**\ ’s ``stellar.toml``
+- ``function_name`` is ``web_auth_verify``
+- An ``args`` map containing the following Symbol to String pairs:
+
+  - ``account`` matches the ``account`` from the request
+  - ``home_domain`` matches the ``home_domain`` from the request
+  - ``web_auth_domain`` matches the **Server**\ ’s domain
+  - ``web_auth_domain_account`` matches the **Server Account**
+  - ``client_domain`` matches the **Client**\ ’s domain if the
+    **Client** included a ``client_domain`` in the request and the
+    server supports `Verifying the Client
+    Domain <#verifying-the-client-domain>`__
+  - ``client_domain_account`` matches the **Client Domain Account** if
+    the **Client** included a ``client_domain`` in the request and the
+    server supports `Verifying the Client
+    Domain <#verifying-the-client-domain>`__
+  - ``nonce`` is a unique value that is the same across all
+    authorization entries
+
+- ``network_passphrase``: (optional but recommended) Stellar network
+  passphrase used by the **Server**. This allows a **Client** to verify
+  that it’s using the correct passphrase when signing and is useful for
+  identifying when a **Client** or **Server** have been configured
+  incorrectly.
+
+Example:
+
+.. code:: json
+
+   {
+     "authorization_entries": "AAAAAgAAAAEAAAABlnDSOHcDpJacwHNIZUmGs7/rY33nansDfdvJ52o9YfZnRkzmy+aWigAAAAAAAAABAAAAAAAAAAGe+9iQNGKMq4+tUhbGm3PTyjNf8oaXfQZRHZVNw11F1wAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoyMzE4NDQ4NTYxAAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAAAAAAAQAAAAAAAAAAjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra0Ul+ctHM344gAZTl0AAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra0AAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAbVnJ5bIh6CzYVp06OGL76q1Cq7Tr7XxnWYbsd7hZdTFygCOByb0Gc3fE1vMujeQpbTXDIm8riyYYwa7QDBmVDwAAAAAAAAABnvvYkDRijKuPrVIWxptz08ozX/KGl30GUR2VTcNdRdcAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQ0xIQlVSWU80QjJKRlU0WUJaVVFaS0pRMlozNzIzRFBYVFdVNllEUFhONFRaM0tIVlE3Tk9VTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAAAVub25jZQAAAAAAAA4AAAAKMjMxODQ0ODU2MQAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAABd3ZWJfYXV0aF9kb21haW5fYWNjb3VudAAAAAAOAAAAOEdDSExIREJPS0cySldNSlFCVExTTDVYRzZOTzdFU1hJMlRBUUtaWENYV1hCNVdJMlg2VzIzM1BSAAAAAA==",
+     "network_passphrase": "Test SDF Network ; September 2015"
+   }
+
+You can examine the example challenge in the `XDR
+Viewer <https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAgAAAAEAAAABlnDSOHcDpJacwHNIZUmGs7//rY33nansDfdvJ52o9YfZnRkzmy+aWigAAAAAAAAABAAAAAAAAAAGe+9iQNGKMq4+tUhbGm3PTyjNf8oaXfQZRHZVNw11F1wAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoyMzE4NDQ4NTYxAAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAAAAAAAQAAAAAAAAAAjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq//ra0Ul+ctHM344gAZTl0AAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq//ra0AAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAbVnJ5bIh6CzYVp06OGL76q1Cq7Tr7XxnWYbsd7hZdTFygCOByb0Gc3fE1vMujeQpbTXDIm8riyYYwa7QDBmVDwAAAAAAAAABnvvYkDRijKuPrVIWxptz08ozX//KGl30GUR2VTcNdRdcAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQ0xIQlVSWU80QjJKRlU0WUJaVVFaS0pRMlozNzIzRFBYVFdVNllEUFhONFRaM0tIVlE3Tk9VTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAAAVub25jZQAAAAAAAA4AAAAKMjMxODQ0ODU2MQAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAABd3ZWJfYXV0aF9kb21haW5fYWNjb3VudAAAAAAOAAAAOEdDSExIREJPS0cySldNSlFCVExTTDVYRzZOTzdFU1hJMlRBUUtaWENYV1hCNVdJMlg2VzIzM1BSAAAAAA==&type=SorobanAuthorizationEntries;;>`__
+
+Error
+'''''
+
+Every other HTTP status code will be considered an error. For example:
+
+.. code:: json
+
+   {
+     "error": "The provided account has requested too many challenges recently. Try again later."
+   }
+
+Token
+~~~~~
+
+This endpoint accepts a signed challenge transaction, validates it and
+responds with a session `JSON Web Token <https://jwt.io/>`__
+authenticating the account.
+
+The **Client** submits a challenge (that was previously returned by the
+```challenge`` <#challenge>`__ endpoint) as a HTTP POST request to
+``WEB_AUTH_FOR_CONTRACTS_ENDPOINT`` using one of the following formats
+(both should be equally supported by the server):
+
+- Content-Type: ``application/x-www-form-urlencoded``, body:
+  ``authorization_entries=<XDR (URL-encoded)>``)
+- Content-Type: ``application/json``, body:
+  ``{"authorization_entries": "<XDR>""}``
+
+To validate the challenge transaction the following steps are performed
+by the **Server**. If any of the listed steps fail, then the
+authentication request must be rejected — that is, treated by the
+**Server** as an invalid input.
+
+1.  Extract the arguments from the authorization entries returned by the
+    client;
+2.  Verify that the ``contract_address`` in each authorization entry
+    matches the ``WEB_AUTH_CONTRACT_ID`` from the **Server**\ ’s
+    ``stellar.toml``;
+3.  Verify that the ``function_name`` in each authorization entry is
+    ``web_auth_verify``;
+4.  Verify that the ``args`` in each authorization entry match the
+    expected values and is the same across all authorization entries:
+
+    1. The ``home_domain`` value matches the **Home Domain**;
+    2. The ``web_auth_domain`` value matches the **Server**\ ’s domain;
+    3. The ``web_auth_domain_account`` value matches the **Server
+       Account**;
+    4. The ``client_domain`` is present if ``client_domain_address`` is
+       present;
+    5. The ``client_domain_account`` value matches the **Client Domain
+       Account** if ``client_domain`` is present;
+
+5.  Verify that the ``nonce`` argument is the same across all
+    authorization entries and is valid;
+6.  Verify that there is an authorization entry where
+    ``credentials.address.address`` is the **Server Account** and
+    contains a valid signature from the **Server Account**;
+7.  Verify that there is an authorization entry where
+    ``credentials.address.address`` is the **Client Account** address
+8.  Verify that there is an authorization entry where
+    ``credentials.address.address`` is the **Client Domain Account** if
+    the arguments included a ``client_domain_account``.
+9.  Construct a transaction with a single Invoke Host Function operation
+    where the contract address is ``WEB_AUTH_CONTRACT_ID`` and the
+    function is ``web_auth_verify`` using the previously extracted
+    arguments and the authorization entries returned by the client;
+10. Simulate the transaction and verify that it succeeds.
+
+The verification process confirms that the **Client** controls the
+**Client Account** and that the challenge was not tampered with.
+Depending on your application this may mean complete signing authority,
+some threshold of control, or being a signer of the account. See
+`Verification <#verification>`__ for examples.
+
+Upon successful verification, **Server** responds with a session JWT,
+containing the following claims:
+
+- ``iss`` (the principal that issued a token, `RFC7519, Section
+  4.1.1 <https://tools.ietf.org/html/rfc7519#section-4.1.1>`__) — a
+  `Uniform Resource Identifier
+  (URI) <https://en.wikipedia.org/wiki/Uniform_Resource_Identifier>`__
+  for the issuer (``https://example.com`` or
+  ``https://example.com/G...``)
+- ``sub`` (the principal that is the subject of the JWT, `RFC7519,
+  Section 4.1.2 <https://tools.ietf.org/html/rfc7519#section-4.1.2>`__)
+  — the **Client Account**\ ’s address (``C...``).
+- ``iat`` (the time at which the JWT was issued `RFC7519, Section
+  4.1.6 <https://tools.ietf.org/html/rfc7519#section-4.1.6>`__) —
+  current timestamp (``1530644093``)
+- ``exp`` (the expiration time on or after which the JWT must not be
+  accepted for processing, `RFC7519, Section
+  4.1.4 <https://tools.ietf.org/html/rfc7519#section-4.1.4>`__) — a
+  server can pick its own expiration period for the token
+  (``1530730493``)
+- ``client_domain`` - (optional) a nonstandard JWT claim containing the
+  client home domain, included if the challenge transaction contained a
+  ``client_domain`` (see `Verifying the Client
+  Domain <#verifying-the-client-domain>`__)
+
+The JWT may contain other claims specific to your application, see
+`RFC7519 <https://tools.ietf.org/html/rfc7519>`__.
+
+The **Server** should not provide more than one JWT for a specific
+challenge transaction.
+
+.. _request-1:
+
+Request
+^^^^^^^
+
+::
+
+   POST <WEB_AUTH_ENDPOINT>
+
+Request Parameters:
+
++----------------------+-----+-----------------------------------------+
+| Name                 | T   | Description                             |
+|                      | ype |                                         |
++======================+=====+=========================================+
+| ``aut                | str | XDR-encoded                             |
+| horization_entries`` | ing | ``SorobanAuthorizationEntries``         |
++----------------------+-----+-----------------------------------------+
+
+Example:
+
+.. code:: json
+
+   {
+     "authorization_entries": "AAAAAgAAAAEAAAABlnDSOHcDpJacwHNIZUmGs7/rY33nansDfdvJ52o9YfY51ZdNL9aPLwAZTnYAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgc9BxIehQRcrSbV5UWjmD7v5mZrUeY4McNq8KBQ1IBVwAAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAFAj75HYJqqG0QpphHhCYl+RRRBj462A2pI2UUATnzFcbTXK5khvnRPjHuHfDhT1QiaRKX26iP0LCq/F3QVbCBAAAAAAAAAABnvvYkDRijKuPrVIWxptz08ozX/KGl30GUR2VTcNdRdcAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQ0xIQlVSWU80QjJKRlU0WUJaVVFaS0pRMlozNzIzRFBYVFdVNllEUFhONFRaM0tIVlE3Tk9VTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAAAVub25jZQAAAAAAAA4AAAAJMzIyMjIxMzk5AAAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAABd3ZWJfYXV0aF9kb21haW5fYWNjb3VudAAAAAAOAAAAOEdDSExIREJPS0cySldNSlFCVExTTDVYRzZOTzdFU1hJMlRBUUtaWENYV1hCNVdJMlg2VzIzM1BSAAAAAAAAAAEAAAAAAAAAAI6zjC5RtJsxMAzXJfbm813ySujUwQVm4r2uHtkav62tFed13zXdmEcAGU5tAAAAEAAAAAEAAAABAAAAEQAAAAEAAAACAAAADwAAAApwdWJsaWNfa2V5AAAAAAANAAAAII6zjC5RtJsxMAzXJfbm813ySujUwQVm4r2uHtkav62tAAAADwAAAAlzaWduYXR1cmUAAAAAAAANAAAAQPdJSPwc6k5b33sUbVdPWZyMNO5yiJsUx+K+gWcwsd73GqH8Ywd7SezSHHoIFB2svR8DMwCQESgh7neVK26ojgYAAAAAAAAAAZ772JA0Yoyrj61SFsabc9PKM1/yhpd9BlEdlU3DXUXXAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0NMSEJVUllPNEIySkZVNFlCWlVRWktKUTJaMzcyM0RQWFRXVTZZRFBYTjRUWjNLSFZRN05PVUwAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACTMyMjIyMTM5OQAAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAXd2ViX2F1dGhfZG9tYWluX2FjY291bnQAAAAADgAAADhHQ0hMSERCT0tHMkpXTUpRQlRMU0w1WEc2Tk83RVNYSTJUQVFLWlhDWFdYQjVXSTJYNlcyMzNQUgAAAAA="
+   }
+
+You can examine the example signed entries in the `XDR
+Viewer <https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAgAAAAEAAAABlnDSOHcDpJacwHNIZUmGs7//rY33nansDfdvJ52o9YfY51ZdNL9aPLwAZTnYAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgc9BxIehQRcrSbV5UWjmD7v5mZrUeY4McNq8KBQ1IBVwAAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAFAj75HYJqqG0QpphHhCYl+RRRBj462A2pI2UUATnzFcbTXK5khvnRPjHuHfDhT1QiaRKX26iP0LCq//F3QVbCBAAAAAAAAAABnvvYkDRijKuPrVIWxptz08ozX//KGl30GUR2VTcNdRdcAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQ0xIQlVSWU80QjJKRlU0WUJaVVFaS0pRMlozNzIzRFBYVFdVNllEUFhONFRaM0tIVlE3Tk9VTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAAAVub25jZQAAAAAAAA4AAAAJMzIyMjIxMzk5AAAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAABd3ZWJfYXV0aF9kb21haW5fYWNjb3VudAAAAAAOAAAAOEdDSExIREJPS0cySldNSlFCVExTTDVYRzZOTzdFU1hJMlRBUUtaWENYV1hCNVdJMlg2VzIzM1BSAAAAAAAAAAEAAAAAAAAAAI6zjC5RtJsxMAzXJfbm813ySujUwQVm4r2uHtkav62tFed13zXdmEcAGU5tAAAAEAAAAAEAAAABAAAAEQAAAAEAAAACAAAADwAAAApwdWJsaWNfa2V5AAAAAAANAAAAII6zjC5RtJsxMAzXJfbm813ySujUwQVm4r2uHtkav62tAAAADwAAAAlzaWduYXR1cmUAAAAAAAANAAAAQPdJSPwc6k5b33sUbVdPWZyMNO5yiJsUx+K+gWcwsd73GqH8Ywd7SezSHHoIFB2svR8DMwCQESgh7neVK26ojgYAAAAAAAAAAZ772JA0Yoyrj61SFsabc9PKM1//yhpd9BlEdlU3DXUXXAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0NMSEJVUllPNEIySkZVNFlCWlVRWktKUTJaMzcyM0RQWFRXVTZZRFBYTjRUWjNLSFZRN05PVUwAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACTMyMjIyMTM5OQAAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAXd2ViX2F1dGhfZG9tYWluX2FjY291bnQAAAAADgAAADhHQ0hMSERCT0tHMkpXTUpRQlRMU0w1WEc2Tk83RVNYSTJUQVFLWlhDWFdYQjVXSTJYNlcyMzNQUgAAAAA=&type=SorobanAuthorizationEntries;;>`__
+
+.. _response-1:
+
+Response
+^^^^^^^^
+
+If the **Server** successfully validates the submitted challenge
+transaction, the endpoint should return ``200 OK`` HTTP status code and
+a JSON object with the following fields:
+
++----+---+------------------------------------------------------------+
+| Na | T | Description                                                |
+| me | y |                                                            |
+|    | p |                                                            |
+|    | e |                                                            |
++====+===+============================================================+
+| `  | s | The JWT that can be used to authenticate future endpoint   |
+| `t | t | calls with the anchor                                      |
+| ok | r |                                                            |
+| en | i |                                                            |
+| `` | n |                                                            |
+|    | g |                                                            |
++----+---+------------------------------------------------------------+
+
+Example:
+
+.. code:: json
+
+   {
+     "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJsb2NhbGhvc3Q6ODA4MCIsInN1YiI6IkNDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMIiwiaWF0IjoxNzM3MTQyMjI0LCJleHAiOjE3MzcxNDI1MjQsImp0aSI6IjI2MWQ3ZjAyMzljOTMxMDVmMmU1NGJjMWZkYzk2OGY5ZTY4MTUyOTQ1MjljMjQwZDgxMzgwY2U3MGQyYzUyMjAiLCJob21lX2RvbWFpbiI6ImxvY2FsaG9zdDo4MDgwIn0.WrtL94Erny9DpfXehA0dfnpmNvDPPuh3_0oxAT16xuw"
+   }
+
+Check the example session token on
+`JWT.IO <https://jwt.io/#debugger-io?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJsb2NhbGhvc3Q6ODA4MCIsInN1YiI6IkNDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMIiwiaWF0IjoxNzM3MTQyMjI0LCJleHAiOjE3MzcxNDI1MjQsImp0aSI6IjI2MWQ3ZjAyMzljOTMxMDVmMmU1NGJjMWZkYzk2OGY5ZTY4MTUyOTQ1MjljMjQwZDgxMzgwY2U3MGQyYzUyMjAiLCJob21lX2RvbWFpbiI6ImxvY2FsaG9zdDo4MDgwIn0.WrtL94Erny9DpfXehA0dfnpmNvDPPuh3_0oxAT16xuw>`__.
+
+Every other HTTP status code will be considered an error. For example:
+
+.. code:: json
+
+   {
+     "error": "The provided authorization entries are not valid"
+   }
+
+Web Authentication Contract
+---------------------------
+
+The **Server** must deploy a contract at the ``WEB_AUTH_CONTRACT_ID``
+address specified in the **Server**\ ’s ``stellar.toml``. This contract
+allows the **Server** to customize authentication logic, including
+client domain verification and nonce handling.
+
+The contract must implement the ``web_auth_verify`` function with the
+following signature. Within this function, the contract should call
+``require_auth`` on the address to ensure the client has authorized the
+operation, and call ``require_auth`` on the **Server Account** so that
+the **Server** can verify that the challenge has not been tampered.
+
+If the **Server** supports client domain verification, the contract can
+optionally call ``require_auth`` on the client domain address. All other
+arguments are ignored by the contract.
+
+The server should include a ``nonce`` in the ``web_auth_verify``
+function arguments. The ``nonce`` is a random string generated by the
+**Server** and included in the challenge transaction. The ``nonce`` is
+verified when the **Client** submits signed challenge to the **Server**.
+The ``nonce`` is used to prevent replay attacks.
+
+Below is an example implementation of the ``web_auth_verify`` function
+in Rust:
+
+.. code:: rust
+
+   #[contracterror]
+   pub enum WebAuthError {
+       MissingArgument = 1,
+   }
+
+   #[contractimpl]
+   impl WebAuthContract {
+       pub fn __constructor(env: Env, admin: Address) -> () {
+           env.storage().instance().set(&DataKey::Admin, &admin);
+       }
+
+       /// Verifies the client is authorized to authenticate with the server
+       ///
+       /// Arguments:
+       /// - account: The client account address
+       /// - home_domain: The home domain
+       /// - web_auth_domain: The server's domain
+       /// - web_auth_domain_account: The server's SIGNING_KEY
+       /// - client_domain: The client domain (optional)
+       /// - client_domain_account: The client domain's SIGNING_KEY (optional)
+       /// - nonce: A random string generated by the server to prevent replay attacks
+       pub fn web_auth_verify(env: Env, args: Map<Symbol, String>) -> Result<(), WebAuthError> {
+           if let Some(address) = args.get(Symbol::new(&env, "account")) {
+               let addr = Address::from_string(&address);
+               addr.require_auth();
+           } else {
+               return Err(WebAuthError::MissingArgument);
+           }
+
+           if let Some(web_auth_domain_account) = args.get(Symbol::new(&env, "web_auth_domain_account")) {
+               let addr = Address::from_string(&web_auth_domain_account);
+               addr.require_auth();
+           } else {
+               return Err(WebAuthError::MissingArgument);
+           }
+
+           // Optional client domain verification
+           if let Some(client_domain_account) = args.get(Symbol::new(&env, "client_domain_account")) {
+               let addr = Address::from_string(&client_domain_account);
+               addr.require_auth();
+           }
+
+           Ok(())
+       }
+   }
+
+Replay Prevention
+-----------------
+
+A replay attack is when an attacker uses a previously signed challenge
+to impersonate a **Client** after the original authentication was
+completed. Both the **Server** and the **Client** share responsibility
+for preventing replay attacks. Using only one of these approaches
+described below is insufficient to protect against replay attacks; both
+must be implemented together for complete protection.
+
+Nonce Verification
+~~~~~~~~~~~~~~~~~~
+
+The **Server** must provide a nonce for each challenge request. The
+nonce should be a unique value, even for the identical requests. The
+**Server** should verify that the nonce is present in the signed
+challenge and has not been used before. This ensures that a signed
+challenge can only be used once. Additionally, the **Server** should
+reject any `token <#token>`__ requests that include a nonce that is too
+old. This limits the time window an attack can use a signed challenge if
+intercepted or stolen.
+
+Storing and verifying all nonces for uniqueness might not be practical
+for every implementation. Therefore, servers should not depend solely on
+nonce verification.
+
+Setting Signature Expiration Ledger
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Client Side:** The **Client** should set the signature expiration
+  ledger to a near-future ledger (for example, the current ledger plus
+  1). This limits the window in which a signature can be reused.
+- **Server Side:** The **Server** should either:
+
+  - Use its own signature expiration ledger on its challenge signature
+    to restrict its validity, and/or
+  - Reject client signatures that use a signature expiration ledger that
+    it deems too old.
+
+In summary, even though nonces are always included in challenge requests
+to ensure signature uniqueness, both the **Server** and the **Client**
+must, at a minimum, enforce signature expiration ledgers to effectively
+narrow the replay window.
+
+Verification
+------------
+
+Verifying the Client Domain
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A web service requiring SEP-45 authentication may want to attribute each
+HTTP request made to it to a specific **Client** software. For example,
+a web service may want to offer reduced fees for the users of a specific
+**Client**.
+
+In order to use this optional feature, the organization that provides
+the **Client** must host a `SEP-1 stellar.toml <sep-0001.md>`__ file
+containing a ``SIGNING_KEY`` attribute (i.e. the **Client Domain
+Account**). The ``SIGNING_KEY`` attribute must be a Stellar public key
+in the form of a ``G`` address. The secret key paired with the
+``SIGNING_KEY`` should be protected as anyone in possession of the
+secret can verify the **Client Domain**.
+
+This setup allows the **Server** to verify that the challenge returned
+by the **Client** is also signed by the **Client Domain Address**,
+proving that the **Client** is associated with the **Client Domain**.
+Web services requiring SEP-45 authentication can now attribute requests
+made with the resulting JWT to the **Client Domain** that signed the
+challenge.
+
+**Servers** may choose which **Client Domains** to verify. If the
+**Client** requests verification of its domain but the **Server** has no
+use for verifying that domain, the **Server** should proceed as if the
+**Client** did not provide the domain in the request for the challenge
+transaction. If the **Server** attempts but is unable to fetch the
+``SIGNING_KEY`` from the provided **Client Domain**, the **Server**
+should return a ``400 Bad Request`` HTTP status code.
+
+JWT Expiration
+--------------
+
+Servers should select an expiration time for the JWT that is appropriate
+for the assumptions and risk of the interactions the **Client** can
+perform with it. A **Client** may be in control of an account at the
+time the JWT is issued but they may lose control of the account through
+a change in signers. Expiration times that are too long increase the
+risk that control on the account has changed. Expiration times that are
+too short increase the number of times authentication must reoccur, and
+a user using a hardware signing device or who must complete a complex
+signing process could have a poor user experience.
+
+A convention for signatures
+---------------------------
+
+Signatures in Stellar involve both the secret key of the signer and the
+passphrase of the network. SEP-45 clients and servers must use the
+following convention when deciding what network passphrase to use for
+signing and verifying signatures in SEP-45:
+
+- If the server is for testing purposes or interacts with the Stellar
+  testnet, use the Stellar testnet passphrase.
+- Otherwise, use the Stellar pubnet passphrase.
+
+This convention ensures that SEP-45 clients and servers can use the same
+passphrase as they’re using for interacting with the Stellar network.
+
+The client can examine the ``network_passphrase`` (if defined) that the
+server includes in its response from the challenge endpoint to be sure
+it’s using the correct passphrase and is connecting to the server that
+it expected.
+
+JWT best practices
+------------------
+
+When generating and validating JWTs it’s important to follow best
+practices. The IETF is in the process of producing a set of best current
+practices when using JWTs: `IETF JWT
+BCP <https://tools.ietf.org/wg/oauth/draft-ietf-oauth-jwt-bcp/>`__.
+
+Implementations
+---------------
+
+The web authentication contract described in this document has been
+deployed to the following networks:
+
+- Pubnet: ``CALI6JC3MSNDGFRP7Z2OKUEPREHOJRRXKMJEWQDEFZPFGXALA45RAUTH``
+
+  - Wasm hash:
+    ``3c8d0b8b347752e57abe0b50380401ca8f5793bc971b685fd072571bbf5d54cc``
+  - Deployed code:
+    https://github.com/stellar/sep45-reference/blob/3dcabc965f01512a631d2c0c6999786f5f6a01cd/contracts/web_auth/src/lib.rs
+  - Build Attestation:
+    https://github.com/stellar/sep45-reference/attestations/16654165
+
+Changelog
+---------
+
+- ``0.1.1``: Handle archived SEP-45 contract instances
+  (`#1827 <https://github.com/stellar/stellar-protocol/pull/1827>`__)
+- ``0.1.0``: Initial draft

--- a/docs/sep-58.rst
+++ b/docs/sep-58.rst
@@ -1,0 +1,1485 @@
+Preamble
+--------
+
+::
+
+   SEP: 0058
+   Title: External Account API
+   Author: TBD
+   Status: Draft
+   Created: 2026-03-19
+   Updated: 2026-03-21
+   Discussion: TBD
+   Version 0.3.0
+
+Summary
+-------
+
+This SEP defines a standard API for wallets and other Stellar clients to
+request provisioned inbound receiving instruments from a provider.
+
+Examples include:
+
+- crypto deposit addresses (e.g. Ethereum, Base, Arbitrum)
+- virtual bank accounts (e.g. ACH virtual account, SEPA IBAN)
+- bank account credentials (e.g. CLABE, SPEI)
+
+The provisioned instrument is bound to the authenticated user’s Stellar
+wallet and is intended to receive off-chain or external-network deposits
+that settle to that wallet.
+
+This SEP uses bearer authentication obtained via
+`SEP-10 <sep-0010.md>`__ for classic (G…) and muxed (M…) accounts, or
+`SEP-45 <sep-0045.md>`__ for contract (C…) accounts. Providers
+supporting all Stellar account types must implement both authentication
+protocols.
+
+This SEP is independent from `SEP-6 <sep-0006.md>`__ and
+`SEP-24 <sep-0024.md>`__. It provisions an account resource. It does not
+create a deposit transaction.
+
+Motivation
+----------
+
+`SEP-6 <sep-0006.md>`__ already allows anchors to return deposit
+instructions, but those instructions are transaction-scoped: the wallet
+asks for instructions to complete a specific deposit flow, and the
+anchor returns credentials for *that* deposit. Many providers also need
+a standard way to provision reusable receiving instruments outside a
+specific deposit or withdrawal flow.
+
+This SEP standardizes that simpler object:
+
+- discover what receiving instruments a provider supports
+- request one for the authenticated user
+- poll for its status
+- retrieve the credentials needed to receive funds
+
+The design stays close to existing Stellar conventions:
+
+- discovery via `SEP-1 <sep-0001.md>`__
+- authentication via `SEP-10 <sep-0010.md>`__ or
+  `SEP-45 <sep-0045.md>`__
+- credential fields via `SEP-9 <sep-0009.md>`__
+- credential payload shape and callback signing via
+  `SEP-6 <sep-0006.md>`__
+- KYC remediation via `SEP-12 <sep-0012.md>`__
+
+Why Not Extend SEP-6?
+~~~~~~~~~~~~~~~~~~~~~
+
+`SEP-6 <sep-0006.md>`__ models deposits as transactions. Each
+``GET /deposit`` call creates a new transaction with its own ``id``,
+``status``, and lifecycle. Some anchors have worked around this by
+returning the same deposit address across multiple SEP-6 transactions
+(`stellar-protocol#1341 <https://github.com/stellar/stellar-protocol/issues/1341>`__),
+but this creates ambiguity: the client expects a transaction, the anchor
+returns a reusable account, and reconciliation becomes unclear.
+
+The core difference is resource identity:
+
++--------------------------+--------------------+-----------------------+
+| Concern                  | SEP-6              | SEP-58                |
++==========================+====================+=======================+
+| Resource                 | Transaction        | Account (reusable     |
+|                          | (one-time deposit  | receiving instrument) |
+|                          | flow)              |                       |
++--------------------------+--------------------+-----------------------+
+| Lifecycle                | ``incomplete`` ->  | ``pending`` ->        |
+|                          | ``pending_use      | ``active`` ->         |
+|                          | r_transfer_start`` | ``deactivated``       |
+|                          | -> ``completed``   |                       |
++--------------------------+--------------------+-----------------------+
+| Credential scope         | Bound to one       | Bound to one user,    |
+|                          | transaction        | reusable across       |
+|                          |                    | deposits              |
++--------------------------+--------------------+-----------------------+
+| Idempotency              | Each call may      | Same params return    |
+|                          | create a new       | the same account      |
+|                          | transaction        |                       |
++--------------------------+--------------------+-----------------------+
+| ``GET /transactions``    | Lists              | N/A – accounts are    |
+|                          | deposit/withdrawal | not transactions      |
+|                          | history            |                       |
++--------------------------+--------------------+-----------------------+
+
+A SEP-6 extension
+(`stellar-protocol#1372 <https://github.com/stellar/stellar-protocol/issues/1372>`__)
+could add async deposit instructions, but it would overload the
+transaction model with account semantics. SEP-58 keeps both models
+clean: SEP-6 for transactions, SEP-58 for accounts.
+
+Providers may implement both. A provider can provision an account via
+SEP-58 and accept SEP-6 deposits into that same account. The
+``instructions`` payload uses the same `SEP-9 <sep-0009.md>`__ field
+names in both protocols.
+
+If a provider needs transaction amount, quote context, flow-specific
+settlement instructions, or any other transaction-scoped input before it
+can determine the correct receiving instructions, the provider should
+use `SEP-6 <sep-0006.md>`__ or `SEP-24 <sep-0024.md>`__ instead of
+SEP-58.
+
+Relationship to Stellar Account Types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Stellar supports three address types that may appear as authenticated
+subjects and as settlement destinations in this SEP:
+
+- **Classic accounts (G…)** are authenticated via
+  `SEP-10 <sep-0010.md>`__. A classic account may optionally include a
+  memo to identify a sub-account within a shared Stellar account.
+
+- **Muxed accounts (M…)** are authenticated via
+  `SEP-10 <sep-0010.md>`__. A muxed account (CAP-27) encodes a 64-bit
+  sub-account ID directly in the address, solving Stellar-to-Stellar
+  routing without on-chain memo coordination. A muxed account may appear
+  directly as the ``stellar_account`` in a SEP-58 account object. When
+  ``stellar_account`` is a muxed account, ``memo`` must be omitted.
+
+- **Contract accounts (C…)** are authenticated via
+  `SEP-45 <sep-0045.md>`__. A contract account is a Soroban smart
+  contract that abstracts account ownership. Contract accounts are the
+  sole authenticated subject in a SEP-45 session. ``memo`` must not be
+  used to encode ownership or sub-identity for a contract account; the
+  contract account itself is the subject.
+
+SEP-58 solves a different problem than any of these address types:
+provisioning *off-chain* or *external-network* receiving instruments
+(bank accounts, crypto addresses on other chains) that map to a Stellar
+destination. A muxed or contract account may appear as the
+``stellar_account``, but neither can provision an ACH virtual account
+number or an Ethereum deposit address on its own.
+
+Out of Scope
+------------
+
+This SEP does not define:
+
+- cards or card references (PCI compliance makes these a distinct
+  problem)
+- payout instruments (this SEP is inbound-only)
+- internal provider reconciliation or settlement timing
+- `SEP-6 <sep-0006.md>`__ or `SEP-24 <sep-0024.md>`__ transaction
+  creation
+- a global registry of payment rails
+- exchange rates or quotes (see `SEP-38 <sep-0038.md>`__)
+- client-triggered deactivation (may be added in a future version)
+- how providers validate bearer tokens internally (see `Token
+  Validation <#token-validation>`__)
+
+Definitions
+-----------
+
+- **Provider**: a server implementing this SEP (often an anchor, but not
+  necessarily limited to anchors)
+- **Account**: a provisioned inbound receiving instrument
+- **Offering**: a specific supported combination a client may request
+- **Authenticated subject**: the identity established by the bearer
+  token. For SEP-10, this is the classic account (G…) with optional memo
+  semantics, or the muxed account (M…). For SEP-45, this is the contract
+  account (C…).
+
+Account kinds:
+
+- ``crypto_address``: a blockchain deposit address
+- ``virtual_account``: a provider-provisioned inbound account mapped to
+  the user
+- ``bank_account``: bank account credentials the provider instructs the
+  client to use
+
+Design Principles
+-----------------
+
+- One resource: ``account``
+- One discovery key: ``EXTERNAL_ACCOUNT_SERVER``
+- One canonical credential payload: ``instructions``
+- One obvious control path: authenticate, inspect offerings, create or
+  fetch account, poll status
+- Conservative reuse by default: providers should return an existing
+  compatible account when possible
+- Explicit support matrices: clients must not infer rail-country
+  compatibility from separate lists
+
+Diagram
+-------
+
+.. code:: mermaid
+
+   sequenceDiagram
+       participant Wallet
+       participant Provider
+       participant User
+
+       Wallet->>+Provider: GET /.well-known/stellar.toml
+       Provider-->>-Wallet: EXTERNAL_ACCOUNT_SERVER, auth config
+
+       Wallet->>+Provider: GET /info
+       Provider-->>-Wallet: explicit offerings
+
+       alt Classic or Muxed account (G... / M...)
+           Wallet->>+Provider: GET <WEB_AUTH_ENDPOINT> (SEP-10 challenge)
+           Provider-->>-Wallet: challenge transaction
+           Wallet->>+Provider: POST <WEB_AUTH_ENDPOINT> (signed challenge)
+           Provider-->>-Wallet: JWT (sub = G... or M...)
+       else Contract account (C...)
+           Wallet->>+Provider: GET <WEB_AUTH_FOR_CONTRACTS_ENDPOINT> (SEP-45 challenge)
+           Provider-->>-Wallet: authorization entries
+           Wallet->>+Provider: POST <WEB_AUTH_FOR_CONTRACTS_ENDPOINT> (signed entries)
+           Provider-->>-Wallet: JWT (sub = C...)
+       end
+
+       Wallet->>+User: choose offering
+       User-->>-Wallet: confirm
+       Wallet->>+Provider: POST /accounts (Bearer JWT)
+       Provider-->>-Wallet: account object (pending or active)
+       Wallet->>+Provider: GET /accounts/:id (Bearer JWT)
+       Provider-->>-Wallet: updated account object
+
+Discovery
+---------
+
+Providers implementing this SEP must publish an HTTPS endpoint in
+```stellar.toml`` <sep-0001.md>`__:
+
+.. code:: toml
+
+   EXTERNAL_ACCOUNT_SERVER="https://api.example.com/sep58"
+
+The key follows the descriptive naming convention used by other SEPs
+(``TRANSFER_SERVER`` for SEP-6, ``ANCHOR_QUOTE_SERVER`` for SEP-38). The
+endpoint represents the root of this SEP’s API.
+
+``EXTERNAL_ACCOUNT_SERVER`` discovers only the SEP-58 API root.
+Authentication is discovered separately through SEP-1:
+
+- Clients authenticating classic or muxed accounts discover SEP-10 via
+  ``WEB_AUTH_ENDPOINT`` and ``SIGNING_KEY`` in ``stellar.toml``.
+- Clients authenticating contract accounts must also discover SEP-45 via
+  ``WEB_AUTH_FOR_CONTRACTS_ENDPOINT``, ``WEB_AUTH_CONTRACT_ID``, and
+  ``SIGNING_KEY`` in ``stellar.toml``.
+
+Providers supporting contract-account authentication must publish the
+SEP-45 authentication metadata required to obtain bearer tokens for C…
+accounts.
+
+Authentication
+--------------
+
+This SEP uses bearer authentication obtained via
+`SEP-10 <sep-0010.md>`__ or `SEP-45 <sep-0045.md>`__:
+
+- `SEP-10 <sep-0010.md>`__ authenticates classic (G…) and muxed (M…)
+  accounts.
+- `SEP-45 <sep-0045.md>`__ authenticates Soroban contract (C…) accounts.
+- Providers supporting all Stellar account types must implement both.
+- A provider may implement only SEP-10 or only SEP-45. If so, it should
+  make that limitation clear in documentation and discovery. Providers
+  claiming full account-type support must implement both.
+
+``GET /info`` may be accessed without authentication.
+
+All other endpoints require:
+
+::
+
+   Authorization: Bearer <jwt>
+
+The bearer token may originate from either SEP-10 or SEP-45. SEP-58 does
+not distinguish between the two at the endpoint level; it consumes a
+valid JWT and relies on the issuing protocol to define how the token was
+minted and validated. SEP-58 standardizes only the identity and
+authorization consequences once a valid session exists.
+
+Subject Binding Rules
+~~~~~~~~~~~~~~~~~~~~~
+
+The provisioned account must be bound to the authenticated subject. The
+binding rules depend on the authentication protocol:
+
++------------------------+---------------------+-----------------------+
+| Auth Protocol          | JWT Subject         | Binding Rule          |
++========================+=====================+=======================+
+| SEP-10 (classic)       | G…                  | Bind to the classic   |
+|                        |                     | account. If the JWT   |
+|                        |                     | includes memo         |
+|                        |                     | semantics per SEP-10, |
+|                        |                     | scope to that         |
+|                        |                     | sub-identity.         |
++------------------------+---------------------+-----------------------+
+| SEP-10 (muxed)         | M…                  | Bind to the muxed     |
+|                        |                     | identity. ``memo``    |
+|                        |                     | must be omitted in    |
+|                        |                     | the account object.   |
++------------------------+---------------------+-----------------------+
+| SEP-45 (contract)      | C…                  | Bind to the contract  |
+|                        |                     | account. ``memo``     |
+|                        |                     | must not be used for  |
+|                        |                     | sub-identity; the     |
+|                        |                     | contract account is   |
+|                        |                     | the sole subject.     |
++------------------------+---------------------+-----------------------+
+
+**Invariant**: ``stellar_account`` in the returned account object must
+represent the same bound destination identity used for provisioning. A
+provider must not return a ``stellar_account`` that differs from the
+authenticated subject’s intended settlement destination.
+
+Client Domain Attribution
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`SEP-45 <sep-0045.md>`__ supports optional ``client_domain``
+verification and an optional ``client_domain`` JWT claim. In the context
+of SEP-58:
+
+- Providers may use verified ``client_domain`` information from a
+  SEP-45-authenticated session for policy decisions, attribution, rate
+  limiting, or analytics.
+- Lack of ``client_domain`` must not change account ownership semantics.
+- ``client_domain`` never changes the idempotency key or account owner;
+  it is metadata about the client software, not about the authenticated
+  subject.
+- ``client_domain`` is not part of any SEP-58 request or response
+  object.
+
+Content Type
+------------
+
+All requests and responses use:
+
+- ``application/json``
+
+HTTPS Only
+----------
+
+This protocol handles the movement of value. Providers and clients must
+use HTTPS for all endpoints.
+
+CORS
+----
+
+Provider servers must implement
+`CORS <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`__ to
+allow browser-based wallets to access the API. At minimum:
+
+- ``Access-Control-Allow-Origin: *`` for ``GET /info``
+- Appropriate ``Access-Control-Allow-Origin`` headers for authenticated
+  endpoints
+
+This is consistent with the CORS expectations of `SEP-1 <sep-0001.md>`__
+and `SEP-6 <sep-0006.md>`__.
+
+Errors
+------
+
+Errors should return an appropriate HTTP status code and a JSON response
+body.
+
+Common status codes:
+
++--------+------------+------------------------------------------------+
+| Status | Name       | Reason                                         |
+| Code   |            |                                                |
++========+============+================================================+
+| `      | Bad        | The request is invalid or cannot be satisfied  |
+| `400`` | Request    | as requested.                                  |
++--------+------------+------------------------------------------------+
+| `      | Permission | Authentication is required or the token is not |
+| `403`` | Denied     | accepted.                                      |
++--------+------------+------------------------------------------------+
+| `      | Not Found  | The requested account does not exist for the   |
+| `404`` |            | authenticated user.                            |
++--------+------------+------------------------------------------------+
+
+``403`` responses include but are not limited to:
+
+- Missing bearer token.
+- Token not accepted (expired, malformed, or signature invalid).
+- SEP-10 token presented for a contract account that requires SEP-45
+  authentication, or vice versa.
+- SEP-45 token not valid for the requested contract subject.
+
+Standard error body:
+
+.. code:: json
+
+   {
+     "error": "The requested offering is not supported."
+   }
+
+If additional customer information is required, providers should respond
+with ``403`` and a body following the non-interactive customer
+information pattern used by `SEP-6 <sep-0006.md>`__ and
+`SEP-12 <sep-0012.md>`__:
+
+.. code:: json
+
+   {
+     "type": "non_interactive_customer_info_needed",
+     "fields": ["birth_date", "address"]
+   }
+
+Providers may also include ``more_info_url`` when they require an
+interactive browser-based remediation flow:
+
+.. code:: json
+
+   {
+     "type": "non_interactive_customer_info_needed",
+     "fields": ["birth_date", "address"],
+     "more_info_url": "https://api.example.com/kyc/flow/abc123"
+   }
+
+KYC requirements in this SEP must be derived only from:
+
+- the authenticated subject
+- the requested offering
+
+If a provider needs transaction amount, quote context, or any other
+transaction-scoped input to determine KYC requirements, the provider
+should use `SEP-6 <sep-0006.md>`__ or `SEP-24 <sep-0024.md>`__ instead
+of SEP-58.
+
+Data Formats
+------------
+
+Country Codes
+~~~~~~~~~~~~~
+
+``country_code`` uses `ISO 3166-1
+alpha-2 <https://www.iso.org/iso-3166-country-codes.html>`__ codes such
+as ``US``, ``MX``, and ``DE``. This is consistent with the country code
+format used by `SEP-6 <sep-0006.md>`__ and `SEP-38 <sep-0038.md>`__, and
+aligns with the format used by most financial APIs (ISO 20022, SWIFT,
+IBAN).
+
+Note: `SEP-9 <sep-0009.md>`__ uses alpha-3 for some KYC fields. This SEP
+uses alpha-2 because it matches the convention already established by
+SEP-6 and SEP-38 for API parameters, and because alpha-2 is the dominant
+format in payment systems that providers and clients already integrate
+with.
+
+Currency Codes
+~~~~~~~~~~~~~~
+
+``currency`` uses `ISO
+4217 <https://www.iso.org/iso-4217-currency-codes.html>`__ codes such as
+``USD``, ``MXN``, and ``EUR``.
+
+Rail
+~~~~
+
+``rail`` is a provider-published string identifying the payment network
+used for the receiving instrument. This SEP intentionally does not
+define a global rail enum. Rails vary by region, provider capability,
+and regulatory context.
+
+Rail values should be uppercase, stable, and recognizable. Providers
+must publish actual supported combinations in ``GET /info``.
+
+Recommended values for common rails:
+
+=========== ====================================
+Rail        Description
+=========== ====================================
+``ACH``     US Automated Clearing House
+``SEPA``    Single Euro Payments Area
+``SPEI``    Mexico Sistema de Pagos Electronicos
+``SWIFT``   SWIFT international wire
+``PIX``     Brazil instant payment system
+``FEDWIRE`` US Fedwire Funds Service
+=========== ====================================
+
+This table is non-normative. Providers may use other values for rails
+not listed here.
+
+Chain Identifiers
+~~~~~~~~~~~~~~~~~
+
+``chain_id`` uses the
+`CAIP-2 <https://chainagnostic.org/CAIPs/caip-2>`__ format
+(``namespace:reference``). CAIP-2 is used because SEP-58 provisions
+deposit addresses on non-Stellar chains (Ethereum, Base, Arbitrum, etc.)
+where no Stellar-native identifier exists. Providers must also include a
+human-readable ``network`` string so clients do not need to interpret
+CAIP identifiers on their own.
+
+Examples:
+
+================== ================
+``chain_id``       ``network``
+================== ================
+``eip155:1``       Ethereum Mainnet
+``eip155:10``      Optimism
+``eip155:8453``    Base
+``eip155:56``      BNB Smart Chain
+``eip155:42161``   Arbitrum One
+``stellar:pubnet`` Stellar Mainnet
+================== ================
+
+The Stellar namespace uses the identifiers defined in
+`CAIP-28 <https://chainagnostic.org/CAIPs/caip-28>`__.
+
+Stellar Asset Format
+~~~~~~~~~~~~~~~~~~~~
+
+``stellar_asset`` identifies the Stellar asset credited when funds
+received through this account are settled on Stellar. The value uses the
+`SEP-11 <sep-0011.md>`__ format:
+
+- ``native`` for XLM
+- ``Code:Issuer`` for issued assets
+  (e.g. ``USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN``)
+
+Instructions
+~~~~~~~~~~~~
+
+The ``instructions`` object reuses the credential payload shape defined
+by `SEP-6 <sep-0006.md>`__: keys are `SEP-9 <sep-0009.md>`__ financial
+account fields and values are objects with ``value`` and
+``description``.
+
+This version of the SEP supports only receiving credentials that can be
+expressed using `SEP-9 <sep-0009.md>`__ field names. Keys must use the
+field names as defined in SEP-9, including the ``organization.`` prefix
+where the corresponding field is defined that way.
+
++----+---+---------------------------------------------------------------+
+| Na | T | Description                                                   |
+| me | y |                                                               |
+|    | p |                                                               |
+|    | e |                                                               |
++====+===+===============================================================+
+| `  | s | The value of the field.                                       |
+| `v | t |                                                               |
+| al | r |                                                               |
+| ue | i |                                                               |
+| `` | n |                                                               |
+|    | g |                                                               |
++----+---+---------------------------------------------------------------+
+| `  | s | A human-readable description of the field. This can be used   |
+| `d | t | to provide any additional information about fields that are   |
+| es | r | not defined in the SEP-9 standard.                            |
+| cr | i |                                                               |
+| ip | n |                                                               |
+| ti | g |                                                               |
+| on |   |                                                               |
+| `` |   |                                                               |
++----+---+---------------------------------------------------------------+
+
+Example (bank payment):
+
+.. code:: json
+
+   {
+     "organization.bank_account_number": {
+       "value": "1234567890",
+       "description": "Account number"
+     },
+     "organization.bank_number": {
+       "value": "021000021",
+       "description": "ACH routing number"
+     }
+   }
+
+Example (crypto address):
+
+.. code:: json
+
+   {
+     "organization.crypto_address": {
+       "value": "0xAbCDef0123456789aBCdef0123456789abCDef01",
+       "description": "Deposit address"
+     }
+   }
+
+Example (crypto address with memo):
+
+.. code:: json
+
+   {
+     "organization.crypto_address": {
+       "value": "rN7hxPaEBfhCKjQhnGriWNsFbEyR7iMRrg",
+       "description": "XRP deposit address"
+     },
+     "organization.crypto_memo": {
+       "value": "1847203",
+       "description": "Destination tag -- required"
+     }
+   }
+
+Example (Mexican CLABE):
+
+.. code:: json
+
+   {
+     "organization.clabe_number": {
+       "value": "646180111803859359",
+       "description": "CLABE number"
+     }
+   }
+
+Endpoints
+---------
+
+- ```GET /info`` <#get-info>`__
+- ```POST /accounts`` <#post-accounts>`__
+- ```GET /accounts`` <#get-accounts>`__
+- ```GET /accounts/:id`` <#get-accountsid>`__
+
+GET /info
+---------
+
+This endpoint describes what the provider can provision.
+
+Providers must publish explicit offerings, not separate lists of
+countries, currencies, and rails. Clients should never have to guess
+whether a rail applies to a country or currency.
+
+.. _authentication-1:
+
+Authentication
+~~~~~~~~~~~~~~
+
+Optional.
+
+Request
+~~~~~~~
+
+No request arguments are required.
+
+Response
+~~~~~~~~
+
+A successful response returns ``200 OK``.
+
+============= ===== =======================================
+Name          Type  Description
+============= ===== =======================================
+``offerings`` array A list of explicit supported offerings.
+============= ===== =======================================
+
+Offering fields vary by ``kind``.
+
+Common offering fields:
+
++-------------------------------+------------+------------------------+
+| Name                          | Type       | Description            |
++===============================+============+========================+
+| ``kind``                      | string     | One of                 |
+|                               |            | ``crypto_address``,    |
+|                               |            | ``virtual_account``,   |
+|                               |            | or ``bank_account``.   |
++-------------------------------+------------+------------------------+
+| ``country_code``              | string     | Required for           |
+|                               |            | ``virtual_account``    |
+|                               |            | and ``bank_account``.  |
+|                               |            | ISO 3166-1 alpha-2.    |
++-------------------------------+------------+------------------------+
+| ``currency``                  | string     | Required for           |
+|                               |            | ``virtual_account``    |
+|                               |            | and ``bank_account``.  |
+|                               |            | ISO 4217.              |
++-------------------------------+------------+------------------------+
+| ``rail``                      | string     | Required for           |
+|                               |            | ``virtual_account``    |
+|                               |            | and ``bank_account``.  |
++-------------------------------+------------+------------------------+
+| ``chain_id``                  | string     | Required for           |
+|                               |            | ``crypto_address``.    |
+|                               |            | CAIP-2 identifier.     |
++-------------------------------+------------+------------------------+
+| ``network``                   | string     | Required for           |
+|                               |            | ``crypto_address``.    |
+|                               |            | Human-readable network |
+|                               |            | name.                  |
++-------------------------------+------------+------------------------+
+
+Providers may include additional provider-specific fields in each
+offering object (e.g. ``description``, ``min_deposit``,
+``max_deposit``). Clients should ignore fields they do not recognize.
+
+Example:
+
+.. code:: json
+
+   {
+     "offerings": [
+       {
+         "kind": "virtual_account",
+         "country_code": "US",
+         "currency": "USD",
+         "rail": "ACH"
+       },
+       {
+         "kind": "virtual_account",
+         "country_code": "DE",
+         "currency": "EUR",
+         "rail": "SEPA"
+       },
+       {
+         "kind": "bank_account",
+         "country_code": "MX",
+         "currency": "MXN",
+         "rail": "SPEI"
+       },
+       {
+         "kind": "crypto_address",
+         "chain_id": "eip155:1",
+         "network": "Ethereum Mainnet"
+       },
+       {
+         "kind": "crypto_address",
+         "chain_id": "eip155:8453",
+         "network": "Base"
+       }
+     ]
+   }
+
+POST /accounts
+--------------
+
+This endpoint creates or returns a provisioned account for the
+authenticated user.
+
+Providers should be conservative with account creation. If a compatible
+account already exists in ``active`` status, the provider should return
+that account instead of creating a new one. If a compatible account
+exists in ``pending`` status, the provider may return that pending
+account instead of creating a duplicate provisioning request.
+
+Accounts in ``deactivated`` or ``error`` status must not satisfy a new
+provisioning request. The provider must create a new account or return
+another compatible account in ``active`` or ``pending`` status.
+
+The client can detect whether a new account was created by inspecting
+the HTTP status code (``200`` vs ``201``).
+
+.. _authentication-2:
+
+Authentication
+~~~~~~~~~~~~~~
+
+Required. The bearer token may be obtained via `SEP-10 <sep-0010.md>`__
+for G…/M… accounts or `SEP-45 <sep-0045.md>`__ for C… accounts.
+
+.. _request-1:
+
+Request
+~~~~~~~
+
+The request must include ``kind``.
+
+For ``virtual_account`` and ``bank_account``, the request must include:
+
+- ``country_code``
+- ``currency``
+
+``rail`` is optional. If omitted, the provider may choose a compatible
+rail but must return the resolved ``rail`` in the response.
+
+For ``crypto_address``, the request must include:
+
+- ``chain_id``
+
+Optional request fields:
+
++-------------------------------------+----------+--------------------+
+| Name                                | Type     | Description        |
++=====================================+==========+====================+
+| ``on_change_callback``              | string   | An HTTPS callback  |
+|                                     |          | URL for account    |
+|                                     |          | status changes.    |
+|                                     |          | See                |
+|                                     |          | `Webhoo            |
+|                                     |          | ks <#webhooks>`__. |
++-------------------------------------+----------+--------------------+
+
+``on_change_callback`` must be an HTTPS URL. Providers should reject
+non-HTTPS callback URLs with a ``400`` response. This is consistent with
+the HTTPS requirement for callback URLs in `SEP-6 <sep-0006.md>`__.
+
+If ``on_change_callback`` is provided and the provider does not support
+webhooks, the provider should ignore the field rather than reject the
+request.
+
+Request examples:
+
+.. code:: json
+
+   {
+     "kind": "virtual_account",
+     "country_code": "US",
+     "currency": "USD"
+   }
+
+.. code:: json
+
+   {
+     "kind": "bank_account",
+     "country_code": "MX",
+     "currency": "MXN",
+     "rail": "SPEI"
+   }
+
+.. code:: json
+
+   {
+     "kind": "crypto_address",
+     "chain_id": "eip155:1"
+   }
+
+.. _response-1:
+
+Response
+~~~~~~~~
+
+If a new account is created, providers should return ``201 Created``.
+
+If an existing compatible account is returned, providers should return
+``200 OK``.
+
+The response body is wrapped in an ``account`` key:
+
+.. code:: json
+
+   {
+     "account": { ... }
+   }
+
+See `Account Object <#account-object>`__ for the full schema.
+
+GET /accounts
+-------------
+
+This endpoint lists accounts belonging to the authenticated user.
+
+.. _authentication-3:
+
+Authentication
+~~~~~~~~~~~~~~
+
+Required. The bearer token may be obtained via `SEP-10 <sep-0010.md>`__
+for G…/M… accounts or `SEP-45 <sep-0045.md>`__ for C… accounts.
+
+.. _request-2:
+
+Request
+~~~~~~~
+
+Optional query parameter filters:
+
+================ ====== =======================
+Name             Type   Description
+================ ====== =======================
+``kind``         string Filter by account kind.
+``country_code`` string Filter by country code.
+``status``       string Filter by status.
+================ ====== =======================
+
+Example:
+
+::
+
+   GET /accounts?kind=virtual_account&country_code=US
+
+Pagination is not defined in this version. Providers serving users with
+many accounts should return a reasonable default limit. A future version
+of this SEP may standardize cursor-based pagination.
+
+.. _response-2:
+
+Response
+~~~~~~~~
+
+A successful response returns ``200 OK``.
+
+.. code:: json
+
+   {
+     "accounts": [
+       {
+         "id": "acc_123",
+         "kind": "virtual_account",
+         "status": "active",
+         "country_code": "US",
+         "currency": "USD",
+         "rail": "ACH",
+         "stellar_asset": "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+         "stellar_account": "GABCD...",
+         "memo": "123456789",
+         "memo_type": "id",
+         "instructions": {
+           "organization.bank_account_number": {
+             "value": "1234567890",
+             "description": "Account number"
+           },
+           "organization.bank_number": {
+             "value": "021000021",
+             "description": "ACH routing number"
+           }
+         },
+         "more_info_url": "https://api.example.com/accounts/acc_123",
+         "created_at": "2026-03-19T10:00:00Z",
+         "updated_at": "2026-03-19T10:00:00Z"
+       }
+     ]
+   }
+
+GET /accounts/:id
+-----------------
+
+This endpoint returns a single account object for the authenticated
+user.
+
+It is the primary polling endpoint for checking provisioning progress
+and retrieving the final active credentials.
+
+.. _authentication-4:
+
+Authentication
+~~~~~~~~~~~~~~
+
+Required. The bearer token may be obtained via `SEP-10 <sep-0010.md>`__
+for G…/M… accounts or `SEP-45 <sep-0045.md>`__ for C… accounts.
+
+.. _request-3:
+
+Request
+~~~~~~~
+
+No request body is required.
+
+.. _response-3:
+
+Response
+~~~~~~~~
+
+A successful response returns ``200 OK``.
+
+Example ``virtual_account`` response (SEP-10 classic account):
+
+.. code:: json
+
+   {
+     "account": {
+       "id": "acc_123",
+       "kind": "virtual_account",
+       "status": "active",
+       "country_code": "US",
+       "currency": "USD",
+       "rail": "ACH",
+       "stellar_asset": "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+       "stellar_account": "GABCD...",
+       "memo": "123456789",
+       "memo_type": "id",
+       "instructions": {
+         "organization.bank_account_number": {
+           "value": "1234567890",
+           "description": "Account number"
+         },
+         "organization.bank_number": {
+           "value": "021000021",
+           "description": "ACH routing number"
+         }
+       },
+       "more_info_url": "https://api.example.com/accounts/acc_123",
+       "created_at": "2026-03-19T10:00:00Z",
+       "updated_at": "2026-03-19T10:00:00Z"
+     }
+   }
+
+Example ``crypto_address`` response (SEP-10 classic account):
+
+.. code:: json
+
+   {
+     "account": {
+       "id": "acc_456",
+       "kind": "crypto_address",
+       "status": "active",
+       "chain_id": "eip155:1",
+       "network": "Ethereum Mainnet",
+       "stellar_asset": "native",
+       "stellar_account": "GABCD...",
+       "memo": "123456789",
+       "memo_type": "id",
+       "instructions": {
+         "organization.crypto_address": {
+           "value": "0xAbCDef0123456789aBCdef0123456789abCDef01",
+           "description": "Deposit address"
+         }
+       },
+       "more_info_url": "https://api.example.com/accounts/acc_456",
+       "created_at": "2026-03-19T10:00:00Z",
+       "updated_at": "2026-03-19T10:00:00Z"
+     }
+   }
+
+Example ``crypto_address`` response (SEP-45 contract account):
+
+.. code:: json
+
+   {
+     "account": {
+       "id": "acc_789",
+       "kind": "crypto_address",
+       "status": "active",
+       "chain_id": "eip155:8453",
+       "network": "Base",
+       "stellar_asset": "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+       "stellar_account": "CCLHBURYO4B2JFU4YBZUQZKJQ2Z3723DPXTWU6YDPXN4TZ3KHVQ7NOUL",
+       "instructions": {
+         "organization.crypto_address": {
+           "value": "0x9876543210AbCdEf9876543210aBcDeF98765432",
+           "description": "Base deposit address"
+         }
+       },
+       "more_info_url": "https://api.example.com/accounts/acc_789",
+       "created_at": "2026-03-21T14:00:00Z",
+       "updated_at": "2026-03-21T14:00:00Z"
+     }
+   }
+
+Note: The contract account example omits ``memo`` and ``memo_type``
+because the contract account (C…) is the sole authenticated subject.
+Sub-identity via memo does not apply to contract accounts.
+
+Account Object
+--------------
+
+The ``account`` object is intentionally small. Providers should include
+only the fields needed for the chosen kind plus the common lifecycle
+fields below.
+
+Common Fields
+~~~~~~~~~~~~~
+
++----------------------------+---------+------------+-----------------+
+| Name                       | Type    | Required   | Description     |
++============================+=========+============+=================+
+| ``id``                     | string  | Yes        | Stable provider |
+|                            |         |            | identifier for  |
+|                            |         |            | the account.    |
++----------------------------+---------+------------+-----------------+
+| ``kind``                   | string  | Yes        | One of          |
+|                            |         |            | ``cr            |
+|                            |         |            | ypto_address``, |
+|                            |         |            | ``vir           |
+|                            |         |            | tual_account``, |
+|                            |         |            | or              |
+|                            |         |            | ``              |
+|                            |         |            | bank_account``. |
++----------------------------+---------+------------+-----------------+
+| ``status``                 | string  | Yes        | One of          |
+|                            |         |            | ``pending``,    |
+|                            |         |            | ``active``,     |
+|                            |         |            | `               |
+|                            |         |            | `deactivated``, |
+|                            |         |            | or ``error``.   |
++----------------------------+---------+------------+-----------------+
+| ``stellar_asset``          | string  | Yes        | The Stellar     |
+|                            |         |            | asset credited  |
+|                            |         |            | when funds are  |
+|                            |         |            | settled. Uses   |
+|                            |         |            | `SEP-11 <       |
+|                            |         |            | sep-0011.md>`__ |
+|                            |         |            | format:         |
+|                            |         |            | ``native`` for  |
+|                            |         |            | XLM,            |
+|                            |         |            | ``Code:Issuer`` |
+|                            |         |            | for issued      |
+|                            |         |            | assets.         |
++----------------------------+---------+------------+-----------------+
+| ``stellar_account``        | string  | Yes        | The Stellar     |
+|                            |         |            | destination     |
+|                            |         |            | identity bound  |
+|                            |         |            | to this         |
+|                            |         |            | external        |
+|                            |         |            | account. For    |
+|                            |         |            | SEP-10 sessions |
+|                            |         |            | this is the     |
+|                            |         |            | authenticated   |
+|                            |         |            | classic (G…) or |
+|                            |         |            | muxed (M…)      |
+|                            |         |            | destination per |
+|                            |         |            | SEP-10          |
+|                            |         |            | semantics. For  |
+|                            |         |            | SEP-45 sessions |
+|                            |         |            | this is the     |
+|                            |         |            | authenticated   |
+|                            |         |            | contract        |
+|                            |         |            | account (C…).   |
++----------------------------+---------+------------+-----------------+
+| ``memo``                   | string  | No         | Memo used with  |
+|                            |         |            | the bound       |
+|                            |         |            | Stellar         |
+|                            |         |            | destination.    |
+|                            |         |            | Omit when       |
+|                            |         |            | ``st            |
+|                            |         |            | ellar_account`` |
+|                            |         |            | is a muxed      |
+|                            |         |            | account (M…).   |
+|                            |         |            | Omit when       |
+|                            |         |            | ``st            |
+|                            |         |            | ellar_account`` |
+|                            |         |            | is a contract   |
+|                            |         |            | account (C…)    |
+|                            |         |            | authenticated   |
+|                            |         |            | via SEP-45.     |
+|                            |         |            | ``memo`` must   |
+|                            |         |            | not be used to  |
+|                            |         |            | encode          |
+|                            |         |            | ownership or    |
+|                            |         |            | sub-identity    |
+|                            |         |            | for a contract  |
+|                            |         |            | account.        |
++----------------------------+---------+------------+-----------------+
+| ``memo_type``              | string  | No         | One of          |
+|                            |         |            | ``text``,       |
+|                            |         |            | ``id``, or      |
+|                            |         |            | ``hash``.       |
+|                            |         |            | Required when   |
+|                            |         |            | ``memo`` is     |
+|                            |         |            | present.        |
++----------------------------+---------+------------+-----------------+
+| ``instructions``           | object  | No         | Credential      |
+|                            |         |            | payload using   |
+|                            |         |            | `SEP-9 <        |
+|                            |         |            | sep-0009.md>`__ |
+|                            |         |            | financial       |
+|                            |         |            | account fields. |
+|                            |         |            | Present when    |
+|                            |         |            | ``status`` is   |
+|                            |         |            | ``active``.     |
++----------------------------+---------+------------+-----------------+
+| ``more_info_url``          | string  | No         | URL for         |
+|                            |         |            | additional      |
+|                            |         |            | information or  |
+|                            |         |            | remediation.    |
++----------------------------+---------+------------+-----------------+
+| ``created_at``             | string  | Yes        | ISO 8601        |
+|                            |         |            | timestamp.      |
++----------------------------+---------+------------+-----------------+
+| ``updated_at``             | string  | Yes        | ISO 8601        |
+|                            |         |            | timestamp.      |
++----------------------------+---------+------------+-----------------+
+| ``message``                | string  | No         | Human-readable  |
+|                            |         |            | message, useful |
+|                            |         |            | when ``status`` |
+|                            |         |            | is ``pending``  |
+|                            |         |            | or ``error``.   |
++----------------------------+---------+------------+-----------------+
+
+Additional Fields for ``virtual_account`` and ``bank_account``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++------------------------+----------+-------------+-------------------+
+| Name                   | Type     | Required    | Description       |
++========================+==========+=============+===================+
+| ``country_code``       | string   | Yes         | ISO 3166-1        |
+|                        |          |             | alpha-2 country   |
+|                        |          |             | code.             |
++------------------------+----------+-------------+-------------------+
+| ``currency``           | string   | Yes         | ISO 4217 currency |
+|                        |          |             | code.             |
++------------------------+----------+-------------+-------------------+
+| ``rail``               | string   | Yes         | Payment rail used |
+|                        |          |             | for this account. |
++------------------------+----------+-------------+-------------------+
+
+Additional Fields for ``crypto_address``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============ ====== ======== ============================
+Name         Type   Required Description
+============ ====== ======== ============================
+``chain_id`` string Yes      CAIP-2 chain identifier.
+``network``  string Yes      Human-readable network name.
+============ ====== ======== ============================
+
+Status Semantics
+~~~~~~~~~~~~~~~~
+
++---------------------------------------------+------------------------+
+| Status                                      | Meaning                |
++=============================================+========================+
+| ``pending``                                 | The provider has       |
+|                                             | accepted the request   |
+|                                             | but the account is not |
+|                                             | yet ready to receive   |
+|                                             | funds. The client      |
+|                                             | should poll            |
+|                                             | ``GET /accounts/:id``. |
++---------------------------------------------+------------------------+
+| ``active``                                  | The account is         |
+|                                             | provisioned and ready  |
+|                                             | to receive funds.      |
+|                                             | ``instructions`` must  |
+|                                             | be present.            |
++---------------------------------------------+------------------------+
+| ``deactivated``                             | The account should no  |
+|                                             | longer be used for new |
+|                                             | deposits. Previously   |
+|                                             | received funds are not |
+|                                             | affected.              |
++---------------------------------------------+------------------------+
+| ``error``                                   | The provider could not |
+|                                             | provision or maintain  |
+|                                             | the account. Check     |
+|                                             | ``message`` for        |
+|                                             | details.               |
++---------------------------------------------+------------------------+
+
+Providers must not expose usable receiving credentials before the
+account is ready. ``instructions`` must be present only when ``status``
+is ``active``.
+
+Status Transitions
+~~~~~~~~~~~~~~~~~~
+
+::
+
+   pending -> active
+   pending -> error
+   active -> deactivated
+   active -> error
+
+``deactivated`` and ``error`` are terminal. Once an account reaches
+either status, it must not transition back to ``active`` or ``pending``.
+If the client needs a new account, it must create one via
+``POST /accounts``.
+
+This SEP does not define a client-triggered deactivation endpoint.
+Providers may transition an account to ``deactivated`` due to internal
+policy, compliance, or user action handled outside this SEP.
+
+Webhooks
+--------
+
+Polling via ``GET /accounts/:id`` is the primary interoperability path.
+
+Providers may optionally support webhooks for account status changes. If
+they do:
+
+1. The client provides ``on_change_callback`` in the ``POST /accounts``
+   request.
+2. The provider sends an HTTP POST to the callback URL when the account
+   status changes.
+3. The callback body should contain the same account object as returned
+   by ``GET /accounts/:id``.
+
+If a provider does not support webhooks, it should ignore
+``on_change_callback`` rather than reject the request.
+
+Callback Signatures
+~~~~~~~~~~~~~~~~~~~
+
+Providers supporting webhooks must sign callback requests using the
+signature scheme defined by `SEP-6 <sep-0006.md>`__:
+
+- Include a ``Signature`` header with format:
+  ``t=<timestamp>, s=<base64 signature>``
+- Sign the payload ``<timestamp>.<wallet_host>.<body>`` using the
+  provider’s Stellar private key corresponding to the ``SIGNING_KEY`` in
+  their ```stellar.toml`` <sep-0001.md>`__.
+
+Wallets receiving callbacks must:
+
+- Verify the signature against the provider’s ``SIGNING_KEY``.
+- Verify freshness by comparing the timestamp to the current time
+  (reject requests older than 2 minutes).
+
+Security Considerations
+-----------------------
+
+- Providers must bind each account to the authenticated subject. When a
+  memo or muxed account is present in a SEP-10 JWT, the account must be
+  scoped to that specific sub-identity. When a contract account is
+  present in a SEP-45 JWT, the contract account is the sole subject.
+- Providers must treat a SEP-45-authenticated contract account as the
+  sole authenticated subject for ownership and idempotency purposes.
+  Providers must not conflate a contract account with any backing
+  classic account that may participate in Soroban authorization.
+- Providers must not infer memo-based sub-identity semantics for
+  contract-account sessions. The contract account itself is the subject.
+- If ``client_domain`` is present in a SEP-45 JWT, it is attribution
+  metadata only and must not change account ownership, idempotency, or
+  binding.
+- Clients must not assume a rail applies to a country or currency unless
+  that exact combination appears in ``GET /info``.
+- Providers must return only the fields necessary to receive funds.
+- Providers must not expose receiving credentials before the account is
+  ready (``instructions`` only when ``status`` is ``active``).
+- Providers must not expose internal settlement details unless required
+  for user operation.
+- Providers must use HTTPS for all endpoints and callback URLs.
+- Callback signatures prevent replay and relay attacks. Providers must
+  not send callbacks to non-HTTPS URLs.
+
+Implementation Notes
+--------------------
+
+Conservative Reuse
+~~~~~~~~~~~~~~~~~~
+
+Providers are encouraged to return existing compatible accounts rather
+than creating new ones on each ``POST /accounts`` request. This
+simplifies reconciliation for both providers and clients.
+
+Only accounts in ``active`` or ``pending`` status are eligible for
+reuse. Accounts in ``deactivated`` or ``error`` status must not be
+returned for a new provisioning request.
+
+The client can distinguish between a newly created account (``201``) and
+a reused one (``200``).
+
+SEP-6 Interoperability
+~~~~~~~~~~~~~~~~~~~~~~
+
+This SEP is intentionally independent from SEP-6. However, a provider
+may choose to use the same underlying account for both SEP-58
+provisioning and SEP-6 deposit flows. In that case, the provider should
+ensure that the ``instructions`` returned by both protocols are
+consistent.
+
+Idempotency
+~~~~~~~~~~~
+
+Providers should treat ``POST /accounts`` as naturally idempotent for
+the same authenticated subject and offering parameters. If the client
+sends the same request twice, the provider should return the same
+account rather than creating a duplicate.
+
+The idempotency key is the combination of the authenticated subject and
+the fields that define the offering:
+
+- For ``virtual_account`` and ``bank_account``:
+  ``(authenticated_subject, kind, country_code, currency, rail)``
+- For ``crypto_address``: ``(authenticated_subject, kind, chain_id)``
+
+The authenticated subject is defined as:
+
+- **SEP-10 classic session**: the classic account (G…) plus any SEP-10
+  sub-identity semantics (memo) if applicable.
+- **SEP-10 muxed session**: the muxed identity (M…).
+- **SEP-45 session**: the contract account (C…).
+
+If ``rail`` is omitted, the provider should treat the resolved rail as
+part of the key — a request without ``rail`` that resolves to ACH should
+return the same account as a subsequent request explicitly specifying
+``rail: "ACH"``.
+
+KYC Integration
+~~~~~~~~~~~~~~~
+
+If a provider requires KYC information before provisioning, the
+recommended flow is:
+
+1. Client calls ``POST /accounts``.
+2. Provider returns ``403`` with
+   ``type: "non_interactive_customer_info_needed"`` and the required
+   ``fields``.
+3. Client submits KYC information via `SEP-12 <sep-0012.md>`__.
+4. Client retries ``POST /accounts``.
+
+KYC requirements must be derivable from the authenticated subject
+(obtained via SEP-10 or SEP-45) and the requested offering alone. For
+SEP-45-authenticated sessions, the subject is the contract account
+identified by the JWT’s ``sub`` claim. If the provider requires
+transaction-scoped context to determine KYC needs, it should use
+`SEP-6 <sep-0006.md>`__ or `SEP-24 <sep-0024.md>`__.
+
+Token Validation
+~~~~~~~~~~~~~~~~
+
+SEP-58 consumes a bearer token and relies on `SEP-10 <sep-0010.md>`__ or
+`SEP-45 <sep-0045.md>`__ to define how that token was minted and
+validated. This SEP does not standardize how providers validate bearer
+tokens internally. It standardizes only the identity and authorization
+consequences once a valid session exists.
+
+Partial Auth Support
+~~~~~~~~~~~~~~~~~~~~
+
+A provider may implement only `SEP-10 <sep-0010.md>`__ or only
+`SEP-45 <sep-0045.md>`__. If so, the provider should make that
+limitation clear in its documentation and ``stellar.toml`` discovery
+metadata. Providers claiming full Stellar account-type support must
+implement both protocols.
+
+Adoption Context
+~~~~~~~~~~~~~~~~
+
+This SEP addresses a gap observed in production anchor deployments.
+Providers such as Bridge (liquidation addresses), MoneyGram Access
+(deposit account provisioning), and on-chain ramp providers already
+offer reusable receiving instruments but use proprietary APIs. SEP-58
+standardizes the common pattern so that wallets can integrate with
+multiple providers through a single interface.
+
+Changelog
+---------
+
+- ``v0.3.0``: Add normative SEP-45 support throughout. Replace
+  “Relationship to Muxed Accounts” with “Relationship to Stellar Account
+  Types” covering G…, M…, and C… addresses. Add Subject Binding Rules
+  table defining how each auth protocol maps to account ownership. Add
+  Client Domain Attribution subsection. Expand sequence diagram to show
+  SEP-10/SEP-45 auth branches. Expand Discovery section with SEP-45
+  prerequisite metadata (``WEB_AUTH_FOR_CONTRACTS_ENDPOINT``,
+  ``WEB_AUTH_CONTRACT_ID``, ``SIGNING_KEY``). Add auth-mismatch 403
+  cases to Errors section. Update ``stellar_account`` field definition
+  with binding semantics per auth protocol. Tighten ``memo`` /
+  ``memo_type`` rules: must omit for muxed and contract accounts. Add C…
+  contract-account example response. Replace ``user`` with
+  ``authenticated_subject`` in Idempotency section with per-protocol
+  definitions. Expand Security Considerations with
+  contract-account-specific rules. Add Token Validation and Partial Auth
+  Support implementation notes. Expand KYC Integration to reference both
+  auth protocols. Define ``authenticated_subject`` term in Definitions.
+  Add explicit auth-protocol description to each endpoint’s
+  Authentication subsection.
+- ``v0.2.2``: Define explicit idempotency key per kind. Require HTTPS
+  for ``on_change_callback`` URLs, consistent with SEP-6 callback
+  conventions.
+- ``v0.2.1``: Tighten reuse semantics – only ``active``/``pending``
+  accounts are eligible for reuse, ``deactivated``/``error`` are
+  terminal and must not satisfy new requests. Add pending-account reuse
+  clause. Add webhook ignore-if-unsupported fallback. Add KYC scope
+  constraint (only authenticated subject + offering). Add SEP-6 boundary
+  sentence to “Why Not Extend SEP-6?” section. Add v1 instructions
+  scoping to SEP-9 field names. Remove ``PATCH`` endpoint and ``label``
+  field (convenience, not interop). Use canonical ``organization.``
+  prefix in all instruction examples. Strengthen “should” to “must”
+  where behavior is required for interoperability.
+- ``v0.2.0``: Add “Why Not Extend SEP-6?” and “Relationship to Muxed
+  Accounts” sections addressing community review feedback. Rename
+  discovery key from ``SEP58_EXTERNAL_ACCOUNT_SERVER`` to
+  ``EXTERNAL_ACCOUNT_SERVER`` following established naming conventions.
+  Add recommended rail values table with uppercase normalization
+  guidance. Add CAIP-2 justification. Add alpha-2 vs alpha-3 rationale
+  note. Frame PATCH deactivation scope. Add adoption context.
+- ``v0.1.0``: Initial draft.
+
+References
+----------
+
+- `SEP-1: stellar.toml <sep-0001.md>`__
+- `SEP-6: Deposit and Withdrawal API <sep-0006.md>`__
+- `SEP-9: Standard KYC Fields <sep-0009.md>`__
+- `SEP-10: Stellar Web Authentication <sep-0010.md>`__
+- `SEP-11: Txrep – Human-readable Stellar Transactions <sep-0011.md>`__
+- `SEP-12: KYC API <sep-0012.md>`__
+- `SEP-24: Hosted Deposit and Withdrawal <sep-0024.md>`__
+- `SEP-38: Anchor RFQ API <sep-0038.md>`__
+- `SEP-45: Stellar Web Authentication for Contract
+  Accounts <sep-0045.md>`__
+- `CAIP-2: Blockchain ID
+  Specification <https://chainagnostic.org/CAIPs/caip-2>`__
+- `CAIP-28: Blockchain Reference for
+  Stellar <https://chainagnostic.org/CAIPs/caip-28>`__
+- `ISO 3166-1 Country
+  Codes <https://www.iso.org/iso-3166-country-codes.html>`__
+- `ISO 4217 Currency
+  Codes <https://www.iso.org/iso-4217-currency-codes.html>`__

--- a/docs/sep45/polaris-sep45-architecture-2026-03-26.md
+++ b/docs/sep45/polaris-sep45-architecture-2026-03-26.md
@@ -1,0 +1,768 @@
+# SEP-45 Implementation Architecture — Django Polaris BPV
+
+**Date:** 2026-03-26
+**Status:** Research / Pre-implementation
+**Audience:** Senior engineer, architect, technical product lead
+**Spec version:** SEP-45 v0.1.1 (Draft) — [stellar-protocol/ecosystem/sep-0045.md](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md)
+**Discussion:** [stellar-protocol#1620](https://github.com/stellar/stellar-protocol/discussions/1620)
+**Companion research:** `../anchor-platform/sep45-research-memo.md` — Anchor Platform git history analysis
+
+---
+
+## 1. What SEP-45 Is (and Is Not)
+
+SEP-45 is Stellar's web authentication protocol for **contract accounts** (`C...` addresses). It is a companion to SEP-10 — not a replacement.
+
+| | SEP-10 | SEP-45 |
+|---|---|---|
+| Account types | `G...` (ed25519), `M...` (muxed) | `C...` (Soroban contract) only |
+| Challenge format | Stellar transaction (ManageData ops, seq=0) | Soroban authorization entries (XDR) |
+| Verification | Ed25519 signature check against on-chain signers/thresholds | Transaction simulation via Soroban RPC (`require_auth`) |
+| stellar.toml key | `WEB_AUTH_ENDPOINT` | `WEB_AUTH_FOR_CONTRACTS_ENDPOINT` + `WEB_AUTH_CONTRACT_ID` |
+| On-chain dependency | Horizon (optional — unfunded accounts skip threshold check) | **Soroban RPC** (mandatory — simulation is the verification) |
+| Contract required | No | Yes — deployed `web_auth_verify` contract |
+| Status | Active (v3.4.1) | Draft (v0.1.1) |
+
+Services that want to support all Stellar accounts **must implement both SEPs**. The spec is explicit:
+> "This SEP only supports C (contract) accounts. SEP-10 only supports G and M accounts." — [SEP-45 Simple Summary](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md)
+
+---
+
+## 2. Protocol Flow
+
+```
+WALLET                                              ANCHOR SERVER
+  │                                                       │
+  │  1. Fetch stellar.toml (SEP-1)                        │
+  │     → extract WEB_AUTH_FOR_CONTRACTS_ENDPOINT          │
+  │     → extract WEB_AUTH_CONTRACT_ID                     │
+  │     → extract SIGNING_KEY (server G... key)            │
+  │                                                       │
+  │  2. GET /sep45/auth?account=C...&home_domain=x        │
+  │     [&client_domain=wallet.example.com]                │
+  │──────────────────────────────────────────────────────→ │
+  │                                                       │
+  │                        3. Validate params              │
+  │                        4. Generate nonce               │
+  │                        5. Build args map:              │
+  │                           account, home_domain,        │
+  │                           web_auth_domain,             │
+  │                           web_auth_domain_account,     │
+  │                           nonce,                       │
+  │                           [client_domain,              │
+  │                            client_domain_account]      │
+  │                        6. Simulate web_auth_verify()   │
+  │                           on WEB_AUTH_CONTRACT_ID      │
+  │                        7. Extract auth entries          │
+  │                        8. Sign server entry             │
+  │                        9. Store nonce (TTL=auth_timeout)│
+  │                                                       │
+  │  ← 200 {authorization_entries: <XDR>, network_passphrase} │
+  │←──────────────────────────────────────────────────────│
+  │                                                       │
+  │  10. Verify entries:                                   │
+  │      - no sub-invocations                              │
+  │      - contract_address == WEB_AUTH_CONTRACT_ID        │
+  │      - function_name == "web_auth_verify"              │
+  │      - args match expectations                         │
+  │      - server signature valid                          │
+  │  11. Simulate locally → verify footprint               │
+  │      (only nonce read/writes allowed)                  │
+  │  12. Sign client entry (contract __check_auth)         │
+  │  13. Sign client_domain entry (if applicable)          │
+  │                                                       │
+  │  14. POST /sep45/auth                                  │
+  │      {authorization_entries: <signed XDR>}             │
+  │──────────────────────────────────────────────────────→ │
+  │                                                       │
+  │                       15. Decode XDR                    │
+  │                       16. Validate invariants:          │
+  │                           - contract ID match          │
+  │                           - function name match        │
+  │                           - args identical across      │
+  │                             all entries                │
+  │                           - required args present      │
+  │                           - no sub-invocations         │
+  │                           - signature_expiration_ledger│
+  │                             not expired                │
+  │                       17. Verify required auth entries: │
+  │                           - server entry present       │
+  │                           - client entry present       │
+  │                           - client_domain entry        │
+  │                             (if claimed)               │
+  │                       18. Consume nonce (atomic)        │
+  │                       19. Simulate tx in ENFORCE mode   │
+  │                       20. Issue JWT                     │
+  │                                                       │
+  │  ← 200 {token: <JWT>}                                  │
+  │←──────────────────────────────────────────────────────│
+  │                                                       │
+  │  [Bearer <JWT> in Authorization header for all         │
+  │   subsequent SEP-6/12/24/31/38/58 calls]              │
+```
+
+### Critical architectural difference from SEP-10
+
+SEP-10 verifies signatures locally — the server checks ed25519 signatures against on-chain signer lists. SEP-45 **delegates verification to the contract itself** via Soroban transaction simulation. The contract's `__check_auth` function can implement arbitrary auth logic (ed25519, passkeys, multi-sig, social recovery, etc.). The server never needs to know *how* the contract authenticates — it only needs to observe that simulation succeeds.
+
+This means SEP-45 is fundamentally **Soroban RPC-dependent**. No RPC, no auth.
+
+---
+
+## 3. JWT Format
+
+Both SEP-10 and SEP-45 produce JWTs with the same claim structure. The goal is that downstream SEPs operate on a shared authenticated identity without branching on auth mechanism at the request-handling level.
+
+```json
+{
+  "iss": "https://anchor.example.com",
+  "sub": "CABC...XYZ",
+  "iat": 1711411200,
+  "exp": 1711497600,
+  "jti": "a1b2c3...",
+  "client_domain": "wallet.example.com",
+  "home_domain": "anchor.example.com"
+}
+```
+
+**Key difference:** `sub` is always a `C...` address (never `G...`, `M...`, or `G...:memo`). SEP-45 does not provide memo or muxed-account semantics — there is no protocol-level mechanism to distinguish sub-users within a contract account the way SEP-10 does with `G...:memo` or `M...`. A contract wallet *can* represent multiple internal users or approval contexts, but that multiplexing is opaque to the anchor's auth layer.
+
+The spec does not mandate a JWT signing algorithm. The reference implementation uses HS256. Polaris already uses HS256 for SEP-10 JWTs.
+
+**However:** shared JWT shape does not mean zero downstream work. Polaris needs a `WebAuthToken` abstraction (Section 5), downstream SEPs need to accept `C...` in account parameters (Section 9.3), and some SEP-specific handling changes are required. The JWT wire format is compatible; the code that consumes it is not — yet.
+
+---
+
+## 4. Where This Lands in the Polaris Architecture
+
+### 4.1 Current auth flow (SEP-10 only)
+
+```
+Request with Authorization: Bearer <jwt>
+  → polaris/sep10/utils.py:validate_sep10_token() decorator
+    → polaris/sep10/utils.py:check_auth()
+      → polaris/sep10/utils.py:validate_jwt_request()
+        → polaris/sep10/token.py:SEP10Token.__init__()
+          → jwt.decode(token, SERVER_JWT_KEY, "HS256")
+          → Validate sub: G... or M... or G...:memo
+```
+
+**Problem:** `SEP10Token.__init__()` at `polaris/sep10/token.py:56-62` calls `Keypair.from_public_key()` on the `sub` value, which will **reject** a `C...` address with `Ed25519PublicKeyInvalidError`. The token class is hard-coded to assume ed25519 accounts.
+
+### 4.2 Files that need modification
+
+| File | Line(s) | Change |
+|---|---|---|
+| `polaris/settings.py:44-61` | `accepted_seps` list | Add `"sep-45"` |
+| `polaris/settings.py` | New section | Add SEP-45 settings: `SEP45_WEB_AUTH_CONTRACT_ID`, `SEP45_HOME_DOMAINS`, `SEP45_AUTH_TIMEOUT`, `SEP45_JWT_TIMEOUT`, `SOROBAN_RPC_URL` |
+| `polaris/sep10/token.py:17-91` | `SEP10Token.__init__` | Must accept `C...` in `sub` claim. Extract to a shared `AuthToken` or teach `SEP10Token` about contract addresses. |
+| `polaris/sep10/token.py:94-106` | `SEP10Token.account` property | Must handle `C...` prefix (no muxed decomposition, no memo) |
+| `polaris/sep10/utils.py:9-63` | `check_auth`, `validate_jwt_request` | Rename or generalize — these validate JWTs from *either* auth method |
+| `polaris/sep1/views.py:78-88` | `generate_toml` | Add `WEB_AUTH_FOR_CONTRACTS_ENDPOINT` and `WEB_AUTH_CONTRACT_ID` to TOML |
+| `polaris/urls.py` | URL registration | Add conditional `sep-45` URL include |
+| `polaris/models.py:478-497` | `Transaction.stellar_account` | Store `C...` in `stellar_account`. Update docstrings to say "web auth account" not "SEP-10 account". Consider adding `auth_mechanism` field (`sep10`/`sep45`) for auditability. |
+| `polaris/middleware.py` / `polaris/cors.py` | CORS | Add SEP-45 endpoint to allowed origins |
+
+### 4.3 New files
+
+| File | Purpose |
+|---|---|
+| `polaris/webauth/__init__.py` | Shared web-auth module |
+| `polaris/webauth/token.py` | `WebAuthToken` base class |
+| `polaris/webauth/models.py` | `WebAuthNonce` model (DB-backed, atomic consume) |
+| `polaris/webauth/client_domain.py` | Client-domain signer resolution with HTTPS enforcement |
+| `polaris/sep45/__init__.py` | Module init |
+| `polaris/sep45/urls.py` | URL patterns for `/sep45/auth` |
+| `polaris/sep45/views.py` | `SEP45Auth` view (GET challenge, POST token exchange) |
+| `polaris/tests/sep45/` | Test suite |
+
+---
+
+## 5. The Token Abstraction Problem
+
+This is the most consequential design decision. Today, every SEP endpoint receives a `SEP10Token` instance:
+
+```python
+# polaris/sep6/deposit.py:53
+@validate_sep10_token()
+def deposit(token: SEP10Token, request: Request) -> Response:
+```
+
+All 21 integration methods across 8 SEP modules type-hint `token: SEP10Token`. Every downstream consumer accesses `token.account`, `token.muxed_account`, `token.memo`, `token.client_domain`.
+
+### Lesson from Anchor Platform: rename before you extend
+
+Anchor Platform's [PR #1657](https://github.com/stellar/anchor-platform/pull/1657) renamed all `sep10_account` fields to `web_auth_account` *after* SEP-45 was already merged. This is one of the clearest architectural lessons in their entire git history: SEP-10-specific names become wrong the moment SEP-45 exists. If we widen `SEP10Token` without renaming, we create the same debt they had to pay down retroactively.
+
+### Option A: Widen `SEP10Token` to handle `C...` (minimal change)
+
+Modify `SEP10Token.__init__` to accept `C...` addresses in `sub`. Add a `contract_account` property. Keep the class name (or alias it).
+
+**Pros:** Zero changes to integration signatures, decorators, or downstream views.
+**Cons:** The name `SEP10Token` becomes misleading. The `account` property semantics are ambiguous (`G...` vs `C...`). Anchor Platform tried this path and had to rename everything later.
+
+### Option B: Introduce `WebAuthToken` base class first, then add SEP-45
+
+```python
+# polaris/webauth/token.py (new)
+class WebAuthToken:
+    """Authenticated session from SEP-10 or SEP-45."""
+    account: str              # G..., C..., or derived from M...
+    client_domain: str | None
+    home_domain: str | None
+    issued_at: datetime
+    expires_at: datetime
+    payload: dict
+    auth_mechanism: str       # "sep10" or "sep45"
+
+    @property
+    def is_contract_account(self) -> bool:
+        return self._payload["sub"].startswith("C")
+
+# polaris/webauth/sep10.py
+class SEP10Token(WebAuthToken):
+    muxed_account: str | None
+    memo: int | None
+
+# polaris/webauth/sep45.py
+class SEP45Token(WebAuthToken):
+    pass  # no memo, no muxed — contract accounts are single-entity
+```
+
+**Pros:** Clean type semantics. Matches Anchor Platform's `WebAuthJwt` / `Sep45Jwt` hierarchy that survived production. Downstream endpoints type-hint `token: WebAuthToken` — one rename now, never again.
+**Cons:** Requires updating integration base classes and decorators. Real cross-codebase refactor.
+
+### Recommendation: Option B — generalize first
+
+The Anchor Platform history is clear: Option A creates naming debt that must be paid later with a larger, riskier rename under production traffic. The right sequence:
+
+1. Introduce `WebAuthToken` as the base class
+2. Make `SEP10Token` a subclass (backward-compatible — it gains a parent, existing properties unchanged)
+3. Rename the decorator: `validate_sep10_token()` → `validate_web_auth_token()` (alias the old name for backward compat)
+4. Update integration type hints from `SEP10Token` → `WebAuthToken`
+5. Add `SEP45Token` as a second subclass
+6. Rename `validate_jwt_request()` → `validate_web_auth_request()` (old name aliased)
+
+Steps 1-4 can be done as a preparatory refactor **before any SEP-45 endpoint code**. This is the pattern Anchor Platform wished they had followed — [PR #1657](https://github.com/stellar/anchor-platform/pull/1657) was a retroactive cleanup.
+
+### JWT secret separation
+
+Anchor Platform's [PR #1659](https://github.com/stellar/anchor-platform/pull/1659) switched SEP-45 JWT encoding to use a **dedicated secret** instead of the SEP-10 secret. Rationale: sharing secrets across auth mechanisms is unnecessary coupling and makes rotation and blast-radius management worse.
+
+**Decision:** Use a separate `SEP45_JWT_SECRET` from day one. Do not reuse `SERVER_JWT_KEY`.
+
+---
+
+## 6. Soroban RPC Dependency
+
+SEP-45 requires a Soroban RPC endpoint for:
+
+1. **GET (challenge generation):** Simulate `web_auth_verify` to produce auth entries + get current ledger
+2. **POST (token exchange):** Simulate transaction in ENFORCE mode to verify signatures
+
+This is a new infrastructure dependency. SEP-10 only needs Horizon (and even that is optional for unfunded accounts). SEP-45 **cannot function without RPC**.
+
+### RPC calls per auth flow
+
+| Phase | RPC Method | Purpose |
+|---|---|---|
+| GET challenge | `simulateTransaction` | Generate auth entries with correct nonce structure |
+| GET challenge | `getLatestLedger` | Set signature expiration (current + 10) |
+| POST token | `simulateTransaction` (ENFORCE mode) | Verify client signatures |
+
+**Minimum 3 RPC round-trips per authentication.** This is significantly more latency than SEP-10 (zero external calls for unfunded accounts, one Horizon call for funded accounts).
+
+### Settings needed
+
+```
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+SEP45_WEB_AUTH_CONTRACT_ID=CALI6JC3MSNDGFRP7Z2OKUEPREHOJRRXKMJEWQDEFZPFGXALA45RAUTH
+```
+
+Pubnet contract is published: `CALI6JC3MSNDGFRP7Z2OKUEPREHOJRRXKMJEWQDEFZPFGXALA45RAUTH` ([source](https://github.com/stellar/sep45-reference/blob/3dcabc965f01512a631d2c0c6999786f5f6a01cd/contracts/web_auth/src/lib.rs)).
+
+---
+
+## 7. Nonce Storage
+
+The reference implementation uses an in-memory `NonceStore` with a threading lock. This is fine for a single-process Flask server but won't work for production Django deployments (gunicorn workers, horizontal scaling).
+
+### The TOCTOU lesson from Anchor Platform
+
+Anchor Platform's [PR #1906](https://github.com/stellar/anchor-platform/pull/1906) fixed a **nonce TOCTOU race condition** discovered via a HackerOne report. The original implementation had separate verify/use steps — check if nonce exists and is unused, then mark it used. Under concurrent requests, two POST requests with the same nonce could both pass the verify step before either marked it used, producing two valid JWTs for one challenge.
+
+The fix: atomic `verifyAndUse()` backed by a single SQL update predicate: `UPDATE nonce SET used=true WHERE id=? AND used=false AND expires_at > now()`. If the update affects zero rows, the nonce was already consumed or expired.
+
+**This rules out naive cache-based approaches.** `cache.delete()` returns True if the key existed, but most cache backends don't guarantee this is atomic across distributed nodes. `cache.get()` followed by `cache.delete()` is explicitly vulnerable.
+
+### Options
+
+| Backend | Pros | Cons |
+|---|---|---|
+| Database (Django model) | Always available. Atomic via SQL predicate. Auditable. Anchor Platform's production choice. | Needs cleanup job. |
+| Redis `GETDEL` or Lua script | Truly atomic single-key delete-and-return. Fast. | Requires Redis. Less auditable. |
+| Django cache | Simple API. | **Not safe** — `cache.delete()` atomicity is backend-dependent and unauditable. |
+
+### Recommendation: Database-backed nonce model
+
+```python
+# polaris/webauth/models.py
+class WebAuthNonce(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
+    nonce = models.CharField(max_length=64, db_index=True)
+    account = models.CharField(max_length=56)
+    used = models.BooleanField(default=False)
+    expires_at = models.DateTimeField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    used_at = models.DateTimeField(null=True)
+    home_domain = models.CharField(max_length=255, blank=True)
+    client_domain = models.CharField(max_length=255, blank=True)
+
+    class Meta:
+        unique_together = [("account", "nonce")]
+```
+
+```python
+# Atomic consume — single UPDATE, no read-then-write
+def consume_nonce(account: str, nonce: str) -> bool:
+    now = timezone.now()
+    updated = WebAuthNonce.objects.filter(
+        account=account, nonce=nonce, used=False, expires_at__gt=now
+    ).update(used=True, used_at=now)
+    return updated == 1
+```
+
+This matches the pattern that survived Anchor Platform's HackerOne report. The `used` + `expires_at` predicate in a single UPDATE is race-proof at the database level.
+
+### Nonce cleanup
+
+Add a management command or periodic task to delete expired nonces. Anchor Platform uses a `NonceCleanupJob` ([PR #1676](https://github.com/stellar/anchor-platform/pull/1676)). For Django, a simple management command run via cron:
+
+```python
+WebAuthNonce.objects.filter(expires_at__lt=timezone.now()).delete()
+```
+
+---
+
+## 8. Failure Modes Worth Documenting
+
+### 8.1 Ledger race condition
+
+The server sets `signature_expiration_ledger = latest_ledger + 10` on the challenge. If the client takes too long to sign and POST back, the ledger advances past expiration. The POST simulation fails with an opaque error.
+
+**Mitigation:** The reference sets `+10` ledgers (~50 seconds on pubnet). This should be configurable. Document it clearly for wallet developers.
+
+**Anchor impact:** Return a clear error ("authorization entry signature has expired — re-request the challenge"). Consider logging with the delta so operators can tune the buffer.
+
+### 8.2 RPC unavailability
+
+If Soroban RPC is down, SEP-45 auth is completely blocked. SEP-10 auth is unaffected.
+
+**Mitigation:** Monitor RPC health. Consider a circuit breaker that returns 503 with `Retry-After` rather than hanging.
+
+### 8.3 Contract archival
+
+If the `web_auth` contract instance is archived (Soroban state archival), the simulation may fail or require a restore operation.
+
+**Mitigation:** The spec allows the contract instance in the `read_write` footprint. Servers should periodically bump the contract's TTL. Monitor archival status.
+
+### 8.4 XDR payload as attack surface
+
+Anchor Platform's [PR #1900](https://github.com/stellar/anchor-platform/pull/1900) upgraded `java-stellar-sdk` because the XDR decoder had a vulnerability: it allocated memory based on a length prefix before validating the data, enabling OOM attacks. They also added a **100 KB size guard** on raw `authorization_entries` before decoding.
+
+**Mitigation:** Add a size limit on the POST body before XDR parsing. Reject payloads over 100 KB. Treat auth-entry decoding as an attack surface, not trusted protocol data.
+
+### 8.5 RPC auth header propagation
+
+Anchor Platform's [PR #1904](https://github.com/stellar/anchor-platform/pull/1904) fixed a bug where configured RPC authentication headers were not actually propagated into simulation requests. Since SEP-45 is entirely RPC-dependent, broken infra auth silently breaks all SEP-45 auth.
+
+**Mitigation:** Test authenticated RPC providers explicitly. Include RPC auth in integration tests. Add a startup health check that verifies the RPC connection actually works.
+
+### 8.6 Client-domain HTTPS enforcement
+
+Anchor Platform's [PR #1865](https://github.com/stellar/anchor-platform/pull/1865) restored HTTPS for client-domain signer fetching after it had been briefly downgraded to HTTP to make tests pass ([PR #1673](https://github.com/stellar/anchor-platform/pull/1673)). This is a real trust boundary — a malicious network could MITM an HTTP TOML fetch and inject a fake `SIGNING_KEY`.
+
+**Policy:**
+- HTTPS by default, always
+- Fail closed on pubnet — never allow HTTP
+- HTTP fallback only on testnet, gated by `STELLAR_NETWORK_PASSPHRASE` check
+- Bound response size and redirect count for TOML fetching
+
+### 8.7 Home domain normalization
+
+Anchor Platform's [PR #1774](https://github.com/stellar/anchor-platform/pull/1774) fixed home-domain comparison because values from wallets, config, and TOML are **never normalized the same way**. Raw string comparison fails for cases like `example.com` vs `example.com:443` vs `https://example.com`.
+
+**Mitigation:** Compare domains by authority (parsed netloc), not raw string equality. The Polaris SEP-10 code already uses `urlparse()` for this — carry the same pattern into SEP-45.
+
+### 8.8 Sub-invocation attacks
+
+A malicious server could craft auth entries with sub-invocations that transfer assets or modify state. The spec requires clients to check `sub_invocations == []`. The server should also reject entries with sub-invocations on POST.
+
+Both the reference implementation and the spec are clear on this. Our implementation must enforce it on both GET and POST paths.
+
+### 8.9 Args mismatch across entries
+
+All entries must have identical args. The reference implementation validates this by JSON-stringifying each entry's args with sorted keys and comparing. If a client submits entries with different args (e.g., modifying the `account` in one entry), that's an attack vector.
+
+**Implementation:** Reject any POST where args are not byte-identical across all entries.
+
+---
+
+## 9. Mixed SEP-10 + SEP-45 World
+
+### 9.1 Product routing
+
+An anchor needs to decide: does the client authenticate via SEP-10 or SEP-45?
+
+**Answer: the account prefix determines the protocol.**
+
+| Account prefix | Auth protocol | Endpoint |
+|---|---|---|
+| `G...` | SEP-10 | `/auth` |
+| `M...` | SEP-10 | `/auth` |
+| `C...` | SEP-45 | `/sep45/auth` |
+
+This is unambiguous — a `C...` address **cannot** authenticate via SEP-10, and a `G...` address **cannot** authenticate via SEP-45.
+
+### 9.2 stellar.toml changes
+
+Current Polaris TOML generation (`polaris/sep1/views.py:78-80`):
+
+```python
+if "sep-10" in settings.ACTIVE_SEPS:
+    toml_dict["WEB_AUTH_ENDPOINT"] = os.path.join(settings.HOST_URL, "auth")
+    toml_dict["SIGNING_KEY"] = settings.SIGNING_KEY
+```
+
+With SEP-45 active, add:
+
+```python
+if "sep-45" in settings.ACTIVE_SEPS:
+    toml_dict["WEB_AUTH_FOR_CONTRACTS_ENDPOINT"] = os.path.join(settings.HOST_URL, "sep45", "auth")
+    toml_dict["WEB_AUTH_CONTRACT_ID"] = settings.SEP45_WEB_AUTH_CONTRACT_ID
+```
+
+The `SIGNING_KEY` is shared — SEP-45 uses the same server key as SEP-10 (the reference implementation reads `SECRET_SEP10_SIGNING_SEED` for both).
+
+### 9.3 Downstream SEP handling — not as trivial as it looks
+
+The JWT format is identical, so the `Authorization: Bearer <token>` header works mechanically. But Anchor Platform's history shows that "adding SEP-45" is **not an auth-only task**. Within days of the initial SEP-45 merge, they had to ship dedicated PRs for every downstream SEP:
+
+- SEP-6 deposit: [PR #1629](https://github.com/stellar/anchor-platform/pull/1629)
+- SEP-6 withdraw: [PR #1630](https://github.com/stellar/anchor-platform/pull/1630)
+- SEP-24 deposit: [PR #1640](https://github.com/stellar/anchor-platform/pull/1640)
+- SEP-24 withdraw: [PR #1649](https://github.com/stellar/anchor-platform/pull/1649)
+- SEP-12 (KYC): [PR #1647](https://github.com/stellar/anchor-platform/pull/1647)
+- SEP-38 (quotes): [PR #1667](https://github.com/stellar/anchor-platform/pull/1667)
+
+**Implications for specific SEPs:**
+
+| SEP | Impact | Needs work? |
+|---|---|---|
+| SEP-6 | `C...` stored in `Transaction.stellar_account`. No memo/muxed for contract accounts. SEP-6/24 specs now **explicitly allow** either SEP-10 or SEP-45 JWTs and `C...` in request params. | **Yes** — validate `C...` account format in deposit/withdraw request params |
+| SEP-12 (KYC) | The authenticated identity may be a contract account. `CustomerIntegration.get()` and `.put()` receive `C...` in token.account. | **Yes** — anchor's customer integration must handle `C...` identity |
+| SEP-24 (interactive) | Interactive JWT is derived from the initial auth token. But SEP-24 interactive helpers (`polaris/sep24/utils.py`) are tightly shaped around SEP-10 JWT structure and classic-account fields. | **Yes** — session/interactive flow needs review |
+| SEP-31 | Current SEP-31 spec still frames auth in SEP-10 terms. Anchor Platform added contract-account support ([PR #1723](https://github.com/stellar/anchor-platform/pull/1723)) but this has less spec clarity than SEP-6/24/38. | **Defer** unless concrete interop need |
+| SEP-38 (quotes) | SEP-38 explicitly added SEP-45 support. Quote/pricing APIs must accept either bearer token. | **Yes** — minor, mostly token type acceptance |
+| SEP-58 | Already uses `@validate_sep10_token()`. Once renamed to `@validate_web_auth_token()`, works. | **Trivial** |
+
+### 9.3.1 Product constraint: one transaction per contract account
+
+Anchor Platform's [3.2.0-beta.1 release](https://github.com/stellar/anchor-platform/releases/tag/3.2.0-beta.1) surfaced that because memos are not part of SEP-45 semantics, **SEP-6 and SEP-24 withdrawals were limited to one ongoing transaction per contract account**. Classic accounts use memo to multiplex concurrent transactions; contract accounts cannot.
+
+This is a concrete product constraint that leaks directly from protocol identity semantics. Decide early whether to accept it, redesign around it (e.g., use transaction UUID as the disambiguator), or document it as a known limitation.
+
+### 9.4 Self-serve vs admin-assisted vs hybrid
+
+**SEP-45 should be self-serve.** The auth flow is programmatic — wallet signs, server verifies. No human in the loop. The only question is whether contract accounts get different KYC treatment.
+
+Recommendation: treat `C...` accounts the same as `G...` accounts for KYC purposes. The anchor's `CustomerIntegration` can inspect the account prefix if it needs to apply different rules (e.g., requiring additional identity verification for smart contract wallets).
+
+**The auth flow itself requires no admin intervention.** If the wallet can sign, it can authenticate.
+
+---
+
+## 10. Implementation Surface Area
+
+### 10.1 New code
+
+| Component | Estimated LOC | Complexity |
+|---|---|---|
+| **Phase 1: Preparatory refactor** | | |
+| `polaris/webauth/token.py` (base class + aliases) | ~80 | Medium — wide blast radius but mechanically simple |
+| Decorator rename + integration type hints | ~50 (across files) | Low per file, many files |
+| Settings + config validation | ~60 | Low |
+| Transaction model docstring/field updates | ~20 | Low |
+| **Phase 2: SEP-45 core** | | |
+| `polaris/webauth/models.py` (nonce model) | ~40 | Low |
+| `polaris/webauth/client_domain.py` | ~50 | Medium — trust boundary |
+| `polaris/sep45/views.py` (GET + POST) | ~300 | High — Soroban XDR handling, simulation, size guard |
+| `polaris/sep45/urls.py` | ~5 | Trivial |
+| TOML generation + CORS + URL wiring | ~20 | Trivial |
+| Nonce cleanup management command | ~15 | Trivial |
+| **Phase 3-4: Downstream + tests** | | |
+| SEP-6/24/12/38 downstream updates | ~100 (across files) | Medium — contract account identity handling |
+| Tests (unit + integration) | ~400 | Medium — need RPC mocking, concurrent nonce tests, XDR fuzzing |
+
+### 10.2 Dependencies
+
+The reference implementation uses:
+- `stellar_sdk` (already in Polaris) — `SorobanServer`, `TransactionBuilder`, `auth`, `scval`, `xdr`
+- `xdrlib3` (may already be a transitive dep of `stellar_sdk`)
+
+**Verify:** Does `polaris`'s current `stellar-sdk` version support `SorobanServer`, `AuthMode.ENFORCE`, and `SorobanAuthorizationEntry` XDR types? Check `pyproject.toml`.
+
+The reference uses `stellar_sdk.soroban_rpc.AuthMode` which was added in stellar-sdk 10.x. If Polaris is on an older version, this is a required upgrade.
+
+### 10.3 Configuration delta
+
+New `.env` / Django settings:
+
+```ini
+# Required when sep-45 is active
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+SEP45_WEB_AUTH_CONTRACT_ID=CALI6JC...RAUTH
+SEP45_JWT_SECRET=<separate from SERVER_JWT_KEY>
+
+# Optional (defaults shown)
+SEP45_HOME_DOMAINS=                # Falls back to SEP10_HOME_DOMAINS
+SEP45_WEB_AUTH_DOMAIN=             # Falls back to HOST_URL netloc
+SEP45_AUTH_TIMEOUT=900             # Nonce TTL in seconds
+SEP45_JWT_TIMEOUT=86400            # JWT expiration in seconds
+```
+
+**Removed:** `SEP45_SOURCE_SIGNING_SEED` — Anchor Platform's [PR #1697](https://github.com/stellar/anchor-platform/pull/1697) removed this config after discovering it was unnecessary. Use a random account as the simulation source instead of a dedicated signing seed.
+
+**Added:** `SEP45_JWT_SECRET` — separate from `SERVER_JWT_KEY` per [PR #1659](https://github.com/stellar/anchor-platform/pull/1659). Sharing secrets across auth mechanisms is unnecessary coupling and makes rotation worse.
+
+### 10.4 Config validation — ship it first
+
+Anchor Platform's [PR #1639](https://github.com/stellar/anchor-platform/pull/1639) added config validation *after* the core feature was already merged. The anchor-platform memo observes this is a predictable maturity pattern and recommends inverting the sequence.
+
+**Ship hard validation first.** Before any endpoint code, validate at startup:
+- `SOROBAN_RPC_URL` is present and reachable
+- `SEP45_WEB_AUTH_CONTRACT_ID` is a valid `C...` address
+- `SEP45_JWT_SECRET` is present and at least 32 bytes
+- `SEP45_HOME_DOMAINS` are valid hostnames (not URLs)
+- `SEP45_AUTH_TIMEOUT` and `SEP45_JWT_TIMEOUT` are positive integers
+- `SIGNING_SEED` is present (shared with SEP-10)
+
+---
+
+## 11. Open Questions in the Spec
+
+These are real ambiguities or gaps. An implementation must make decisions here.
+
+### 11.1 Sub-signer authorization entries
+
+If a contract account's `__check_auth` requires authorization from sub-signers (e.g., a 2-of-3 multi-sig contract), those signers may need their own auth entries. The spec only describes entries for: client account, server account, optional client domain account.
+
+**Source:** Leigh McCulloch's review comment in [stellar-protocol#1620](https://github.com/stellar/stellar-protocol/discussions/1620).
+
+**Impact:** Unknown. If a contract's `__check_auth` calls `require_auth` on sub-signers, the simulation at GET time should produce those extra entries. But the spec's validation rules (args identical across all entries) might not hold for sub-signer entries that have different credential addresses.
+
+**Decision needed:** Accept additional entries beyond the three specified types, or reject them?
+
+### 11.2 No structured error codes
+
+The spec provides example error strings but no code taxonomy. Clients can't programmatically distinguish "expired nonce" from "invalid contract ID."
+
+**Recommendation:** Use the error strings from the reference implementation (they're specific enough). Optionally add an `error_code` field for programmatic consumption.
+
+### 11.3 No `aud` claim in JWT
+
+Unlike OIDC, the JWT has no `aud` (audience) claim. In theory, a JWT issued by anchor A could be accepted by anchor B if they share signing material.
+
+**Mitigation:** This design uses separate secrets — `SERVER_JWT_KEY` for SEP-10, `SEP45_JWT_SECRET` for SEP-45 (Section 10.3). Each anchor deploys unique values for both. The `iss` claim identifies the issuing anchor. Cross-anchor token replay requires compromising the target anchor's secret, which is an operational security concern independent of the `aud` claim. Not a practical risk for correctly configured deployments, but worth noting if token rotation or multi-tenant deployments become relevant.
+
+### 11.4 JWT algorithm not mandated
+
+The spec says "follow IETF JWT BCP" but doesn't require a specific algorithm. Polaris uses HS256 everywhere. No change needed, but worth noting for interop discussions.
+
+---
+
+## 12. What to Steal
+
+### From the reference implementation (`/sep45-reference/python-sep45/sep45_server.py`)
+
+1. **XDR validation is strict** — `unpacker.get_position() == len(raw)` prevents truncation attacks
+2. **Args comparison is JSON-stringified with sorted keys** — byte-level comparison
+3. **Nonce is keyed by `(account, nonce)` tuple** — prevents cross-account nonce reuse
+4. **Signature expiration ledger is checked against live ledger** — not against a cached value
+5. **Content-Type fallback** — tries JSON body first, then form data (spec requires both)
+6. **Hostname validation** — `urlparse(f"https://{value}").netloc != value` prevents URL injection
+7. **Wildcard domain matching** — `*.example.com` patterns for multi-tenant anchors
+
+### From Anchor Platform's git history (the hard-won lessons)
+
+8. **Generalize names before extending** — rename `sep10_*` → `web_auth_*` as Phase 1, not as cleanup ([PR #1657](https://github.com/stellar/anchor-platform/pull/1657))
+9. **Separate JWT secrets** — one per auth mechanism, not shared ([PR #1659](https://github.com/stellar/anchor-platform/pull/1659))
+10. **Atomic nonce consume** — single SQL `UPDATE ... WHERE used=false AND expires_at > now()` ([PR #1906](https://github.com/stellar/anchor-platform/pull/1906), HackerOne report)
+11. **100KB size guard on auth entries** — before XDR parsing, not after ([PR #1900](https://github.com/stellar/anchor-platform/pull/1900))
+12. **HTTPS-only client-domain fetch on pubnet** — HTTP fallback gated by network passphrase ([PR #1865](https://github.com/stellar/anchor-platform/pull/1865))
+13. **Test RPC auth propagation explicitly** — authenticated RPC providers silently break if headers aren't forwarded ([PR #1904](https://github.com/stellar/anchor-platform/pull/1904))
+14. **Ship config validation before feature code** — validate all required settings at startup ([PR #1639](https://github.com/stellar/anchor-platform/pull/1639))
+15. **Don't invent config you don't need** — `SEP45_SIMULATING_SIGNING_SEED` was removed as unnecessary ([PR #1697](https://github.com/stellar/anchor-platform/pull/1697))
+16. **Domain comparison by authority, not raw string** — wallets, config, and TOML normalize differently ([PR #1774](https://github.com/stellar/anchor-platform/pull/1774))
+17. **Request-shape validation is separate from protocol validation** — malformed requests should return 400, not 500 ([PR #1870](https://github.com/stellar/anchor-platform/pull/1870))
+18. **Use SDK types, not local wrappers** — avoid inventing `SorobanAuthorizationEntryList` when the SDK has `SorobanAuthorizationEntries` ([commit eb383978](https://github.com/stellar/anchor-platform/commit/eb3839787dcae5aa2b7c55cc54714cf2894801d5))
+
+### What NOT to copy from Anchor Platform
+
+- Spring-style bean wiring and deep dependency injection hierarchies
+- The initial merge-then-harden sequence — invert it
+- Shared JWT secret between SEP-10 and SEP-45 (they fixed this in PR #1659)
+- The SEP-10-specific naming they had to rename later
+
+---
+
+## 13. Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Spec is Draft (v0.1.1) — may change before Active | **High** | Build behind feature flag (`"sep-45" in ACTIVE_SEPS`). Isolate in `polaris/sep45/` module. |
+| Contract interface still moving — arg names changed mid-impl ([PR #1702](https://github.com/stellar/anchor-platform/pull/1702)) | **High** | Pin to published contract ID. Expect versioning. |
+| Soroban RPC dependency adds failure mode | **Medium** | Circuit breaker. Health check. Test authenticated RPC providers. ([PR #1904](https://github.com/stellar/anchor-platform/pull/1904)) |
+| `stellar-sdk` version may lack Soroban features / have XDR vulnerabilities | **Medium** | Verify before implementation. Upgrade if needed. ([PR #1900](https://github.com/stellar/anchor-platform/pull/1900)) |
+| `WebAuthToken` refactor has wide blast radius | **Medium** | Do it as Phase 1 before any SEP-45 code. Alias old names. |
+| Downstream SEPs need more work than expected | **Medium** | Budget for SEP-6/24/12/38 follow-up PRs. Anchor Platform needed 6 dedicated PRs within days. |
+| One-transaction-per-contract-account limit | **Low** | Document as known limitation or redesign transaction disambiguation. |
+| Contract archival can break auth | **Low** | TTL monitoring + automatic restore. |
+
+---
+
+## 14. Implementation Sequence
+
+Sequence based on Anchor Platform's evolution — generalize first, then extend:
+
+**Phase 1: Preparatory refactor (no SEP-45 endpoints yet)**
+
+1. **Settings + config validation** — Add `"sep-45"` to `accepted_seps`, add all new settings with strict startup validation. Ship validation before any feature code. ([Lesson: PR #1639](https://github.com/stellar/anchor-platform/pull/1639))
+2. **`WebAuthToken` base class** — Introduce `polaris/webauth/token.py` with `WebAuthToken`. Make `SEP10Token` a subclass. Alias old names for backward compat.
+3. **Rename decorator** — `validate_sep10_token()` → `validate_web_auth_token()` (old name aliased). Update integration type hints `SEP10Token` → `WebAuthToken`. ([Lesson: PR #1657](https://github.com/stellar/anchor-platform/pull/1657))
+4. **Transaction model** — Update docstrings from "SEP-10 account" to "web auth account". Consider adding `auth_mechanism` field via migration.
+
+**Phase 2: SEP-45 core (isolated in `polaris/sep45/`)**
+
+5. **Nonce model** — `WebAuthNonce` Django model with atomic consume via single UPDATE predicate. Add cleanup management command. ([Lesson: PR #1906 TOCTOU fix](https://github.com/stellar/anchor-platform/pull/1906))
+6. **GET endpoint** — Challenge generation (simulate `web_auth_verify`, sign server entry, return XDR). Include 100KB size guard on input, domain normalization.
+7. **POST endpoint** — Token exchange (validate entries, consume nonce atomically, simulate ENFORCE, issue JWT with `SEP45_JWT_SECRET`)
+8. **Client-domain helper** — HTTPS-only on pubnet, HTTP fallback only on testnet. Bound response size and redirects. ([Lesson: PR #1865](https://github.com/stellar/anchor-platform/pull/1865))
+9. **TOML + CORS + URL wiring** — Register `/sep45/auth`, add TOML fields, add to CORS
+
+**Phase 3: Downstream SEP updates**
+
+10. **SEP-6** — Accept `C...` in deposit/withdraw params, handle no-memo identity
+11. **SEP-24** — Review interactive flow session helpers for contract account compatibility
+12. **SEP-12 / SEP-38 / SEP-58** — Accept `WebAuthToken` (likely works after Phase 1 rename)
+13. **SEP-31** — Defer unless concrete interop need
+
+**Phase 4: Hardening**
+
+14. **Tests** — Malformed XDR payloads, concurrent nonce replay, HTTPS client-domain fetch, RPC auth propagation, mixed SEP-10/SEP-45 bearer tokens on same endpoints
+15. **Operational** — RPC health check, nonce cleanup cron, contract TTL monitoring
+
+Phase 1 is the highest-risk work (cross-cutting rename) but creates the cleanest foundation. Phase 2 is isolated. Phase 3 is where Anchor Platform burned the most follow-up PRs.
+
+---
+
+## 15. What to Test Aggressively
+
+From Anchor Platform's post-release fix history, the real bugs live in trust boundaries and edge cases, not the happy path. Prioritize:
+
+1. **Malformed and oversized `authorization_entries`** — XDR decoding as attack surface ([PR #1900](https://github.com/stellar/anchor-platform/pull/1900))
+2. **Duplicate nonce submissions under concurrency** — race the POST endpoint with the same nonce from two threads ([PR #1906](https://github.com/stellar/anchor-platform/pull/1906))
+3. **Client-domain signer fetch over HTTPS** — verify HTTPS enforcement, test HTTP rejection on pubnet ([PR #1865](https://github.com/stellar/anchor-platform/pull/1865))
+4. **Client-domain missing signature** — valid challenge, valid client signature, missing client-domain signature
+5. **Home-domain normalization** — `example.com` vs `example.com:443` vs `https://example.com` ([PR #1774](https://github.com/stellar/anchor-platform/pull/1774))
+6. **RPC auth-header propagation** — test with an authenticated RPC provider, verify headers actually arrive ([PR #1904](https://github.com/stellar/anchor-platform/pull/1904))
+7. **Downstream transaction/quote ownership with `C...` identity** — create transaction with SEP-45 token, query with SEP-10 token for same underlying user, verify isolation
+8. **Mixed SEP-10 and SEP-45 bearer-token handling** — same API surface, different token types
+9. **Request-shape validation** — missing `account`, non-`C...` account, missing `home_domain`, empty `authorization_entries` ([PR #1870](https://github.com/stellar/anchor-platform/pull/1870))
+10. **Expired signature ledger** — simulate slow client signing
+11. **RPC unavailability** — verify 503, not 500 or hang
+12. **Config validation** — missing settings fail at startup, not at first request
+
+Skip integration tests when `SOROBAN_RPC_URL` is not set (Anchor Platform had to do this: [commit 1e0a79e6](https://github.com/stellar/anchor-platform/commit/1e0a79e655c64b990d17c07f5ebe289bd8812db0)).
+
+---
+
+## 16. Logging Policy
+
+### Never log
+
+- Signing seeds
+- JWT secrets
+- Raw JWTs
+- Full raw authorization entries
+- Client-domain signing keys
+
+### Always log (one line per event, grep-friendly)
+
+- Account identifier (`C...`)
+- Auth mechanism (`sep10` / `sep45`)
+- Home domain
+- Client domain (if present)
+- Nonce ID or digest
+- Simulation success/failure
+- Rejection reason (specific — "expired nonce", not "auth failed")
+- RPC provider host
+- Request correlation ID
+
+Pattern: `SEP45 auth=ok account=CABC...XYZ home=example.com client_domain=wallet.example.com nonce=a1b2... rpc_ms=340`
+
+---
+
+## 17. Contract Deployment
+
+The published pubnet contract exists at `CALI6JC3MSNDGFRP7Z2OKUEPREHOJRRXKMJEWQDEFZPFGXALA45RAUTH`.
+
+Source code: [contracts/web_auth/src/lib.rs](https://github.com/stellar/sep45-reference/blob/3dcabc965f01512a631d2c0c6999786f5f6a01cd/contracts/web_auth/src/lib.rs)
+
+The contract implements a single function that takes a **`Map<Symbol, String>` args parameter** — not positional arguments:
+
+```rust
+pub fn web_auth_verify(env: Env, args: Map<Symbol, String>) -> Result<(), WebAuthError> {
+    // Extract "account" from args map → require_auth()
+    // Extract "web_auth_domain_account" from args map → require_auth()
+    // Extract "client_domain_account" from args map (optional) → require_auth()
+}
+```
+
+The args map contains keys: `account`, `home_domain`, `web_auth_domain`, `web_auth_domain_account`, `nonce`, and optionally `client_domain` + `client_domain_account`. The contract extracts address values by symbol key and calls `require_auth()` on each — the Soroban runtime handles signature verification by invoking each contract's `__check_auth`.
+
+This map-based interface is what the server must construct during challenge generation (Section 2, step 5) and what the server validates on POST (all entries must have identical args maps). Earlier versions of the contract used positional parameters ([PR #1702](https://github.com/stellar/anchor-platform/pull/1702) tracked a renaming); the current canonical interface is the map form.
+
+**For testnet:** The same contract must be deployed. The reference repo includes build instructions. Wasm hash: `3c8d0b8b347752e57abe0b50380401ca8f5793bc971b685fd072571bbf5d54cc`.
+
+---
+
+## 18. References
+
+### Specifications
+- [SEP-45 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md) — v0.1.1, Draft
+- [SEP-45 Discussion](https://github.com/stellar/stellar-protocol/discussions/1620) — 17 comments, including Leigh McCulloch's review
+- [SEP-10 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) — v3.4.1, Active
+- [IETF JWT BCP](https://tools.ietf.org/wg/oauth/draft-ietf-oauth-jwt-bcp/) — Referenced by SEP-45
+
+### Reference implementations
+- [sep45-reference repo](https://github.com/stellar/sep45-reference) — Python, TypeScript, Rust implementations
+- Local reference: `/sep45-reference/python-sep45/sep45_server.py` — ~530 LOC Python implementation
+- Local spec copy: `/docs/sep-45.rst` — Full spec in RST format
+
+### Anchor Platform (Java/Kotlin) — git history as lessons
+- [PR #1623: Initial SEP-45 implementation](https://github.com/stellar/anchor-platform/pull/1623) — first merge, not production-hard
+- [PR #1639: Config validation](https://github.com/stellar/anchor-platform/pull/1639) — shipped after feature, should have been first
+- [PR #1657: Rename sep10_account → web_auth_account](https://github.com/stellar/anchor-platform/pull/1657) — the naming debt lesson
+- [PR #1659: Separate SEP-45 JWT secret](https://github.com/stellar/anchor-platform/pull/1659) — blast-radius management
+- [PR #1676: Nonce persistence](https://github.com/stellar/anchor-platform/pull/1676) — database-backed replay protection
+- [PR #1697: Remove unnecessary signing seed config](https://github.com/stellar/anchor-platform/pull/1697) — don't invent config
+- [PR #1702: Contract arg name changes](https://github.com/stellar/anchor-platform/pull/1702) — spec still moving
+- [PR #1774: Home domain normalization](https://github.com/stellar/anchor-platform/pull/1774) — raw string comparison fails
+- [PR #1865: HTTPS client-domain fetch](https://github.com/stellar/anchor-platform/pull/1865) — real trust boundary
+- [PR #1870: Request validation hardening](https://github.com/stellar/anchor-platform/pull/1870) — malformed requests → 500
+- [PR #1900: XDR decoder OOM fix + 100KB guard](https://github.com/stellar/anchor-platform/pull/1900) — auth entries as attack surface
+- [PR #1904: RPC auth header propagation](https://github.com/stellar/anchor-platform/pull/1904) — silent infra auth failure
+- [PR #1906: Nonce TOCTOU race condition](https://github.com/stellar/anchor-platform/pull/1906) — HackerOne report, atomic consume
+- [3.2.0-beta.1 release notes](https://github.com/stellar/anchor-platform/releases/tag/3.2.0-beta.1) — one-tx-per-contract-account limitation
+- Companion research: `../anchor-platform/sep45-research-memo.md`

--- a/docs/sep45/polaris-sep45-todo-2026-03-26.md
+++ b/docs/sep45/polaris-sep45-todo-2026-03-26.md
@@ -1,0 +1,1013 @@
+# SEP-45 Implementation TODO — Django Polaris BPV
+
+**Date:** 2026-03-26
+**Prereq:** `docs/polaris-sep45-architecture-2026-03-26.md`
+**Spec:** SEP-45 v0.1.1 (Draft)
+**stellar-sdk:** 12.1.0 installed (>= 12 required for `AuthMode.ENFORCE`) -- verified compatible
+
+---
+
+## Phase 1: Preparatory Refactor
+
+No SEP-45 endpoints. Goal: generalize the auth layer so Phase 2 drops in cleanly.
+
+---
+
+### 1.1 Add `"sep-45"` to accepted SEPs
+
+**File:** `polaris/settings.py:44-54`
+
+```python
+# Current accepted_seps list (line 44-54)
+accepted_seps = [
+    "sep-1", "sep-6", "sep-6", "sep-10", "sep-12",
+    "sep-24", "sep-31", "sep-38", "sep-58",
+]
+```
+
+- Add `"sep-45"` to the list
+- Fix the duplicate `"sep-6"` on line 47 while here
+
+---
+
+### 1.2 Add SEP-45 settings with startup validation
+
+**File:** `polaris/settings.py` — add new section after line 133 (after `SEP10_CLIENT_ATTRIBUTION_DENYLIST`)
+
+New settings, loaded only when `"sep-45" in ACTIVE_SEPS`:
+
+| Setting | Type | Required | Default | Validation |
+|---|---|---|---|---|
+| `SOROBAN_RPC_URL` | str | Yes | — | Must start with `http`. Must be reachable at startup. |
+| `SEP45_WEB_AUTH_CONTRACT_ID` | str | Yes | — | Must start with `C`. Validate via `Address(value)`. |
+| `SEP45_JWT_SECRET` | str | Yes | — | Min 32 bytes. **Separate from `SERVER_JWT_KEY`**. |
+| `SEP45_HOME_DOMAINS` | list | No | Falls back to `SEP10_HOME_DOMAINS` | Each must be hostname, not URL. |
+| `SEP45_WEB_AUTH_DOMAIN` | str | No | `urlparse(HOST_URL).netloc` | Must be hostname (used for args map and domain comparison). |
+| `SEP45_SIGNATURE_EXPIRATION_BUFFER` | int | No | `10` | Ledgers ahead of current for signature expiration. Must be positive. Configurable so operators can tune for network conditions. |
+| `SEP45_AUTH_TIMEOUT` | int | No | `900` | Must be positive. |
+| `SEP45_JWT_TIMEOUT` | int | No | `86400` | Must be positive. |
+
+**JWT `iss` is a URI, not a bare hostname.** The spec requires `iss` to be "a Uniform Resource Identifier (URI) for the issuer (`https://example.com` or `https://example.com/G...`)" per [SEP-45 Token section](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md) and RFC 7519 Section 4.1.1. The `iss` claim must be constructed from `HOST_URL` (which is already a URI), not from `SEP45_WEB_AUTH_DOMAIN` (which is a bare authority). Example: `iss = settings.HOST_URL` → `"https://anchor.example.com"`. Do not use the bare hostname.
+
+Also require `SIGNING_SEED` when `"sep-45"` is active (shared signing key with SEP-10).
+
+Create `SorobanServer` instance at module level (like `HORIZON_SERVER` on line 86):
+```python
+SOROBAN_SERVER = None
+if "sep-45" in ACTIVE_SEPS:
+    from stellar_sdk import SorobanServer
+    SOROBAN_SERVER = SorobanServer(SOROBAN_RPC_URL)
+```
+
+**Validation order:** Validate all settings at import time (startup). This is the config-before-feature pattern from Anchor Platform [PR #1639](https://github.com/stellar/anchor-platform/pull/1639).
+
+---
+
+### 1.3 Introduce `WebAuthToken` base class
+
+**New file:** `polaris/webauth/__init__.py` (empty)
+**New file:** `polaris/webauth/token.py`
+
+Extract a base class from `polaris/sep10/token.py:17-164`. The base handles JWT decoding, claim validation, and the common properties. `SEP10Token` becomes a subclass.
+
+#### `WebAuthToken` (base)
+
+Handles:
+- JWT decode with configurable secret (passed in or from settings)
+- Required fields: `iss`, `sub`, `iat`, `exp`
+- Timestamp validation (`iat <= now <= exp`)
+- `client_domain` validation
+- Properties: `account`, `client_domain`, `issuer`, `issued_at`, `expires_at`, `payload`
+- New property: `is_contract_account` — `self._payload["sub"].startswith("C")`
+- New property: `auth_mechanism` — `"sep45"` if `C...`, else `"sep10"`
+
+**Critical change in `__init__`:** The current code at `token.py:58-62` calls `Keypair.from_public_key(stellar_account)` which rejects `C...` addresses. The base class must route:
+
+```python
+if stellar_account:
+    if stellar_account.startswith("C"):
+        Address(stellar_account)          # validates C... format
+    else:
+        Keypair.from_public_key(stellar_account)  # validates G... format
+```
+
+Import needed: `from stellar_sdk import Address`
+
+#### `SEP10Token` subclass
+
+Keeps: `muxed_account`, `memo` properties (only relevant for G.../M... accounts).
+
+Override `__init__` to add M.../memo parsing before calling `super().__init__()`, or keep the parsing in the base with branch logic.
+
+**Decision:** Keep all parsing in the base class with prefix-based branching (`M...` → muxed, `C...` → contract, `:` → memo, else → plain G...). This avoids splitting the parsing logic across classes. `muxed_account` and `memo` return `None` for `C...` accounts.
+
+#### Backward compatibility
+
+```python
+# polaris/sep10/token.py — becomes a thin re-export
+from polaris.webauth.token import SEP10Token, WebAuthToken  # noqa: F401
+```
+
+All existing `from polaris.sep10.token import SEP10Token` imports continue to work.
+
+---
+
+### 1.4 Rename auth decorator
+
+**File:** `polaris/sep10/utils.py:24-62`
+
+Current:
+```python
+def validate_sep10_token():
+    ...
+def validate_jwt_request(request: Request) -> SEP10Token:
+    ...
+```
+
+Add new names, alias the old:
+
+```python
+def validate_web_auth_token():
+    """Decorator to validate a SEP-10 or SEP-45 bearer token."""
+    def decorator(view):
+        def wrapper(request, *args, **kwargs):
+            return check_auth(request, view, *args, **kwargs)
+        return wrapper
+    return decorator
+
+# Backward compatibility
+validate_sep10_token = validate_web_auth_token
+```
+
+Update `validate_jwt_request` to accept either `SERVER_JWT_KEY` or `SEP45_JWT_SECRET`:
+
+```python
+def validate_web_auth_request(request: Request) -> WebAuthToken:
+    # Extract Bearer token from Authorization header (unchanged)
+    # Try decoding with SERVER_JWT_KEY first
+    # If that fails and SEP-45 is active, try SEP45_JWT_SECRET
+    # Return WebAuthToken (or SEP10Token subclass)
+```
+
+**Important:** The SEP-45 JWT uses a different secret. The decoder must try both. Order: try `SERVER_JWT_KEY` first (SEP-10 is the common case), then `SEP45_JWT_SECRET`.
+
+Update error message at line 62 from `"SEP-10 token error:"` to `"authentication token error:"`.
+
+---
+
+### 1.5 Update type hints across all consumers
+
+Every file that imports `SEP10Token` for type hints needs updating to `WebAuthToken`. These are the **exact files and lines** (verified by codebase audit):
+
+#### View endpoints (decorator + type hint)
+
+| File | Import lines | Decorator lines | Type hint lines |
+|---|---|---|---|
+| `polaris/sep6/deposit.py` | 38-39 | 53, 61 | 54, 62, 66, 129, 213 |
+| `polaris/sep6/withdraw.py` | 31-32 | 52, 60 | 53, 61, 65, 156 |
+| `polaris/sep6/transaction.py` | 14-15 | 43, 59, 70 | 44, 60, 71 |
+| `polaris/sep6/utils.py` | 9 | — | 17 |
+| `polaris/sep24/deposit.py` | 39-40 | 415 | 416 |
+| `polaris/sep24/withdraw.py` | 44-45 | 432 | 436 |
+| `polaris/sep24/transaction.py` | 13-14 | 30, 44 | 32, 46 |
+| `polaris/sep31/transactions.py` | 17-18 | 43, 76, 118 | 45, 78, 120, 205 |
+| `polaris/sep12/customer.py` | 22-23 | 35, 81, 124, 171, 211 | 36, 82, 125, 173, 212, 288, 324 |
+| `polaris/sep38/prices.py` | 10-11 | 28, 76 | 29, 77, 109, 166 |
+| `polaris/sep38/quote.py` | 16-17 | 34, 46 | 35, 47, 86, 169 |
+| `polaris/sep58/accounts.py` | 10-11 | 21, 30 | 22, 31, 46, 72 |
+| `polaris/shared/endpoints.py` | 27 | — | 212, 272, 379 |
+| `polaris/utils.py` | 41 | — | 457, 532 |
+
+#### Integration base classes (type hint in method signatures + docstrings)
+
+| File | Import line | Type hint lines |
+|---|---|---|
+| `polaris/integrations/customers.py` | 5 | 11, 34, 60, 105, 128, 159 |
+| `polaris/integrations/transactions.py` | 11 | 464, 526, 657, 804, 822, 858 |
+| `polaris/integrations/quote.py` | 6 | 13, 62, 110 |
+| `polaris/integrations/sep31.py` | 6 | 79, 171, 206 |
+| `polaris/integrations/external_account.py` | 3 | 30, 53, 60 |
+
+**Approach:** In each file, change:
+- `from polaris.sep10.token import SEP10Token` → `from polaris.webauth.token import WebAuthToken`
+- `token: SEP10Token` → `token: WebAuthToken`
+- `from polaris.sep10.utils import validate_sep10_token` → `from polaris.webauth.utils import validate_web_auth_token`
+- `@validate_sep10_token()` → `@validate_web_auth_token()`
+
+Keep backward-compatible re-exports in `polaris/sep10/token.py` and `polaris/sep10/utils.py` so any anchor code importing from the old paths still works.
+
+#### Tests
+
+| File | Import line | Usage lines |
+|---|---|---|
+| `polaris/tests/auth_test.py` | 17 | 164, 197, 241, 286, 370 (isinstance checks) |
+| `polaris/tests/sep6/test_deposit.py` | 24 | 32, 308, 338, 400, 436, 466, 498, 531, 563, 604 |
+| `polaris/tests/sep6/test_withdraw.py` | 25 | 34, 317, 353, 470, 515 |
+
+Update imports. The `isinstance(token, SEP10Token)` checks in `auth_test.py` should also pass for `WebAuthToken` since `SEP10Token` is a subclass.
+
+---
+
+### 1.6 Update Transaction model docstrings
+
+**File:** `polaris/models.py:478-497`
+
+Change:
+- Line 479-483: `"The Stellar (G...) account authenticated via SEP-10"` → `"The Stellar account (G... or C...) authenticated via SEP-10 or SEP-45"`
+- Line 485-490: `"The muxed (M...) account authenticated via SEP-10"` → `"The muxed (M...) account authenticated via SEP-10. Always null for SEP-45 (contract) accounts."`
+- Line 492-497: Similar update for `account_memo`
+
+**Optional:** Add `auth_mechanism` field to Transaction model:
+```python
+auth_mechanism = models.CharField(max_length=5, null=True, blank=True)
+# "sep10" or "sep45" — for operational auditability
+```
+This requires a migration. Decide if needed now or later.
+
+Also update the Quote model docstrings (same fields at `polaris/utils.py:521-523, 595-597`).
+
+---
+
+## Phase 2: SEP-45 Core
+
+Isolated in `polaris/sep45/` and `polaris/webauth/`. No changes to existing SEP endpoints.
+
+---
+
+### 2.1 Create `WebAuthNonce` model
+
+**New file:** `polaris/webauth/models.py`
+
+```python
+class WebAuthNonce(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
+    nonce = models.CharField(max_length=64, db_index=True)
+    account = models.CharField(max_length=56)        # C... address
+    used = models.BooleanField(default=False)
+    expires_at = models.DateTimeField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    used_at = models.DateTimeField(null=True, blank=True)
+    home_domain = models.CharField(max_length=255, blank=True, default="")
+    client_domain = models.CharField(max_length=255, blank=True, default="")
+
+    class Meta:
+        unique_together = [("account", "nonce")]
+```
+
+Issue function:
+```python
+def issue_nonce(account: str, home_domain: str, client_domain: str, timeout: int) -> str:
+    nonce = secrets.token_hex(16)
+    expires_at = timezone.now() + timedelta(seconds=timeout)
+    WebAuthNonce.objects.create(
+        nonce=nonce, account=account, expires_at=expires_at,
+        home_domain=home_domain, client_domain=client_domain,
+    )
+    return nonce
+```
+
+Atomic consume function (single UPDATE, no read-then-write):
+```python
+def consume_nonce(account: str, nonce: str) -> bool:
+    now = timezone.now()
+    updated = WebAuthNonce.objects.filter(
+        account=account, nonce=nonce, used=False, expires_at__gt=now
+    ).update(used=True, used_at=now)
+    return updated == 1
+```
+
+This matches the pattern from Anchor Platform [PR #1906](https://github.com/stellar/anchor-platform/pull/1906).
+
+**Migration:** Create `polaris/migrations/XXXX_add_webauthnonce.py` via `makemigrations`.
+
+---
+
+### 2.2 Create nonce cleanup management command
+
+**New file:** `polaris/management/commands/cleanup_nonces.py`
+
+```python
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        deleted, _ = WebAuthNonce.objects.filter(expires_at__lt=timezone.now()).delete()
+        if deleted:
+            logger.info(f"SEP45 nonce cleanup: deleted {deleted} expired nonces")
+```
+
+Run via cron: `*/15 * * * * python manage.py cleanup_nonces`
+
+---
+
+### 2.3 Create client-domain helper
+
+**New file:** `polaris/webauth/client_domain.py`
+
+Resolves the `SIGNING_KEY` from a client domain's `stellar.toml`.
+
+```python
+def get_client_domain_signing_key(client_domain: str) -> str:
+    """Fetch SIGNING_KEY from client_domain's stellar.toml. HTTPS only on pubnet."""
+```
+
+Security requirements (from Anchor Platform [PR #1865](https://github.com/stellar/anchor-platform/pull/1865)):
+- HTTPS by default
+- HTTP fallback **only** when `STELLAR_NETWORK_PASSPHRASE` is testnet passphrase
+- Bound redirect count (max 3)
+- Bound response size (max 100KB)
+- Timeout: `SEP10_CLIENT_ATTRIBUTION_REQUEST_TIMEOUT` (default 3s)
+- Validate `SIGNING_KEY` with `Keypair.from_public_key()`
+
+This largely mirrors the existing `SEP10Auth._get_client_signing_key()` at `polaris/sep10/views.py:319-336`. Extract and generalize.
+
+---
+
+### 2.4 Create SEP-45 views — GET challenge
+
+**New file:** `polaris/sep45/views.py`
+
+#### `SEP45Auth` class (APIView)
+
+##### `get(self, request)` — Challenge generation
+
+Request params:
+- `account` (required) — must start with `C`, validate via `Address(account)`
+- `home_domain` (required) — must match `SEP45_HOME_DOMAINS` patterns (support wildcards)
+- `client_domain` (optional) — must be valid hostname
+
+**Step-by-step implementation** (maps to `sep45_server.py` functions):
+
+1. **Request-shape validation** — return 400 for missing/invalid params before any logic. Separate from protocol validation ([PR #1870](https://github.com/stellar/anchor-platform/pull/1870)).
+
+2. **Validate `account`:**
+   ```python
+   if not account or not account.startswith("C"):
+       return error_response("'account' must be a contract account (C...)", 400)
+   try:
+       Address(account)
+   except:
+       return error_response("invalid 'account'", 400)
+   ```
+
+3. **Validate `home_domain`** — domain normalization by authority, not raw string ([PR #1774](https://github.com/stellar/anchor-platform/pull/1774)):
+   ```python
+   if not home_domain:
+       return error_response("'home_domain' is required", 400)
+   if not any(domain_matches(pattern, home_domain) for pattern in settings.SEP45_HOME_DOMAINS):
+       return error_response(f"invalid 'home_domain'. Accepted: {settings.SEP45_HOME_DOMAINS}", 400)
+   ```
+
+4. **Resolve `client_domain`** (optional):
+   ```python
+   if client_domain:
+       if urlparse(f"https://{client_domain}").netloc != client_domain:
+           return error_response("'client_domain' must be a valid hostname", 400)
+       client_signing_key = get_client_domain_signing_key(client_domain)
+   ```
+
+5. **Build args map as SCVal:**
+   ```python
+   args_map = scval.to_map({
+       scval.to_symbol("account"): scval.to_string(account),
+       scval.to_symbol("home_domain"): scval.to_string(home_domain),
+       scval.to_symbol("web_auth_domain"): scval.to_string(web_auth_domain),
+       scval.to_symbol("web_auth_domain_account"): scval.to_string(settings.SIGNING_KEY),
+       scval.to_symbol("nonce"): scval.to_string(nonce),
+   })
+   # Add client_domain + client_domain_account if present
+   ```
+
+6. **Issue nonce:**
+   ```python
+   nonce = issue_nonce(account, home_domain, client_domain or "", settings.SEP45_AUTH_TIMEOUT)
+   ```
+
+7. **Build and simulate transaction:**
+   ```python
+   rpc = settings.SOROBAN_SERVER
+   source = rpc.load_account(settings.SIGNING_KEY)  # Use signing key as source
+   tx = (
+       TransactionBuilder(source, network_passphrase=settings.STELLAR_NETWORK_PASSPHRASE, base_fee=100)
+       .append_invoke_contract_function_op(
+           contract_id=settings.SEP45_WEB_AUTH_CONTRACT_ID,
+           function_name="web_auth_verify",
+           parameters=[args_map],
+       )
+       .set_timeout(settings.SEP45_AUTH_TIMEOUT)
+       .build()
+   )
+   simulation = rpc.simulate_transaction(tx)
+   ```
+
+8. **Extract auth entries from simulation:**
+   ```python
+   entries = [xdr.SorobanAuthorizationEntry.from_xdr(item) for item in simulation.results[0].auth]
+   ```
+
+9. **Sign server entry** — use configurable buffer, not hardcoded `+10`:
+   ```python
+   latest = rpc.get_latest_ledger()
+   valid_until = latest.sequence + settings.SEP45_SIGNATURE_EXPIRATION_BUFFER  # default 10
+   signed_entries = []
+   for entry in entries:
+       if (entry.credentials.type == xdr.SorobanCredentialsType.SOROBAN_CREDENTIALS_ADDRESS
+           and Address.from_xdr_sc_address(entry.credentials.address.address).address == settings.SIGNING_KEY):
+           signed_entries.append(auth.authorize_entry(
+               entry=entry, signer=Keypair.from_secret(settings.SIGNING_SEED),
+               valid_until_ledger_sequence=valid_until,
+               network_passphrase=settings.STELLAR_NETWORK_PASSPHRASE,
+           ))
+       else:
+           signed_entries.append(entry)
+   ```
+
+10. **Encode and return:**
+    ```python
+    entries_b64 = encode_auth_entries(signed_entries)
+    return Response({
+        "authorization_entries": entries_b64,
+        "network_passphrase": settings.STELLAR_NETWORK_PASSPHRASE,
+    })
+    ```
+
+**Stellar SDK imports needed:**
+```python
+from stellar_sdk import Address, Keypair, SorobanServer, TransactionBuilder, auth, scval, xdr
+from stellar_sdk.soroban_rpc import AuthMode
+```
+
+---
+
+### 2.5 Create SEP-45 views — POST token exchange
+
+##### `post(self, request)` — Token exchange
+
+1. **Size guard** — reject > 100KB before any parsing ([PR #1900](https://github.com/stellar/anchor-platform/pull/1900)):
+   ```python
+   entries_b64 = request.data.get("authorization_entries")
+   if not entries_b64:
+       return error_response("'authorization_entries' is required", 400)
+   if len(entries_b64) > 102400:
+       return error_response("'authorization_entries' payload too large", 400)
+   ```
+
+2. **Decode auth entries** (XDR deserialization with strict validation):
+   ```python
+   entries = decode_auth_entries(entries_b64)
+   # Uses xdrlib3.Unpacker, validates all bytes consumed
+   ```
+
+3. **Resolve `web_auth_domain`:**
+   ```python
+   web_auth_domain = settings.SEP45_WEB_AUTH_DOMAIN
+   ```
+
+4. **Get current ledger:**
+   ```python
+   current_ledger = settings.SOROBAN_SERVER.get_latest_ledger().sequence
+   ```
+
+5. **Validate entries** — comprehensive checks (maps to `validate_auth_entries()`):
+   - For each entry:
+     - Check `credentials.type == SOROBAN_CREDENTIALS_ADDRESS`
+     - Check `signature_expiration_ledger > current_ledger`
+     - Check `sub_invocations` is empty
+     - Check `function.type == SOROBAN_AUTHORIZED_FUNCTION_TYPE_CONTRACT_FN`
+     - Check `contract_address == SEP45_WEB_AUTH_CONTRACT_ID`
+     - Check `function_name == "web_auth_verify"`
+     - Check args is a single map
+   - Verify all entries have identical args (JSON-stringify with sorted keys)
+   - Verify required args: `account`, `home_domain`, `nonce`, `web_auth_domain`, `web_auth_domain_account`
+   - Validate arg values:
+     - `account` starts with `C`
+     - `home_domain` in allowed domains
+     - `web_auth_domain` matches expected
+     - `web_auth_domain_account` matches `SIGNING_KEY`
+   - Check `client_domain` / `client_domain_account` appear together
+   - Verify all required auth addresses present (server, client, optional client_domain)
+   - **Extra auth entries policy** (resolves architecture doc Section 11.1): If the contract's `__check_auth` produces additional auth entries beyond client/server/client-domain (e.g., sub-signers in a multi-sig contract), **accept them** provided they call the same `WEB_AUTH_CONTRACT_ID` with the same `web_auth_verify` function and identical args. Reject entries that call a different contract or have different args. This is the most permissive correct policy — it allows complex `__check_auth` flows while preventing unrelated contract invocations.
+
+6. **Consume nonce atomically:**
+   ```python
+   account = str(args["account"])
+   nonce_value = str(args["nonce"])
+   if not consume_nonce(account, nonce_value):
+       return error_response("invalid or expired nonce", 400)
+   ```
+
+7. **Simulate in ENFORCE mode:**
+   ```python
+   # Rebuild transaction with signed entries
+   tx = TransactionBuilder(source, ...).append_invoke_contract_function_op(
+       contract_id=settings.SEP45_WEB_AUTH_CONTRACT_ID,
+       function_name="web_auth_verify",
+       parameters=[args_scval],
+       auth=entries,  # client-signed entries
+   ).set_timeout(settings.SEP45_AUTH_TIMEOUT).build()
+
+   simulation = rpc.simulate_transaction(tx, auth_mode=AuthMode.ENFORCE)
+   if simulation.error:
+       return error_response(f"transaction simulation failed: {simulation.error}", 400)
+   ```
+
+8. **Issue JWT** — `iss` must be a URI per RFC 7519 Section 4.1.1 and SEP-45 spec:
+   ```python
+   now = int(time.time())
+   claims = {
+       "iss": settings.HOST_URL,                # URI, e.g. "https://anchor.example.com"
+       "sub": str(args["account"]),              # C... address
+       "iat": now,
+       "exp": now + settings.SEP45_JWT_TIMEOUT,
+       "jti": hashlib.sha256(entries_b64.encode()).hexdigest(),
+       "home_domain": str(args["home_domain"]),
+   }
+   if "client_domain" in args:
+       claims["client_domain"] = str(args["client_domain"])
+
+   token = jwt.encode(claims, settings.SEP45_JWT_SECRET, algorithm="HS256")
+   return Response({"token": token})
+   ```
+
+   **Not** `web_auth_domain` (bare hostname). The spec example is `https://example.com`. This matches Polaris SEP-10 behavior (`sep10/views.py:310` uses `os.path.join(settings.HOST_URL, "auth")`).
+   ```
+
+---
+
+### 2.6 XDR encode/decode helpers
+
+**New file:** `polaris/sep45/xdr_utils.py`
+
+```python
+def encode_auth_entries(entries: list[xdr.SorobanAuthorizationEntry]) -> str:
+    """Pack entries to base64. Format: [uint32 count][entry1][entry2]..."""
+
+def decode_auth_entries(payload_b64: str) -> list[xdr.SorobanAuthorizationEntry]:
+    """Unpack base64 to entries. Validate all bytes consumed."""
+```
+
+Uses `xdrlib3.Packer` / `xdrlib3.Unpacker`. Validates `unpacker.get_position() == len(raw)`.
+
+---
+
+### 2.7 Domain normalization and matching
+
+**New file or add to** `polaris/sep45/utils.py`
+
+Anchor Platform [PR #1774](https://github.com/stellar/anchor-platform/pull/1774) proved that raw-string domain comparison fails because wallets, config, and TOML normalize differently (`example.com` vs `https://example.com` vs `example.com:443` vs `localhost:8080`). Compare by **parsed authority**, not raw string.
+
+```python
+def normalize_domain(value: str) -> str:
+    """Normalize a domain value to a bare authority for comparison.
+    Handles: 'example.com', 'https://example.com', 'example.com:443', etc.
+    """
+    if "://" in value:
+        return urlparse(value).netloc
+    # Strip default HTTPS port if present
+    if value.endswith(":443"):
+        return value[:-4]
+    return value
+
+def domain_matches(pattern: str, value: str) -> bool:
+    """Match domain against pattern, supporting *.example.com wildcards.
+    Both pattern and value are normalized before comparison."""
+    value = normalize_domain(value)
+    pattern_norm = normalize_domain(pattern)
+    if pattern_norm.startswith("*."):
+        suffix = pattern_norm[1:]  # ".example.com"
+        return value.endswith(suffix) or value == pattern_norm[2:]
+    return pattern_norm == value
+```
+
+---
+
+### 2.8 URL routing
+
+**New file:** `polaris/sep45/urls.py`
+
+```python
+from django.urls import path
+from polaris.sep45.views import SEP45Auth
+
+urlpatterns = [path("auth", SEP45Auth.as_view())]
+```
+
+**File:** `polaris/urls.py` — add after line 44:
+
+```python
+if "sep-45" in settings.ACTIVE_SEPS:
+    urlpatterns.append(path("sep45/", include("polaris.sep45.urls")))
+```
+
+---
+
+### 2.9 TOML update
+
+**File:** `polaris/sep1/views.py:87-88` — add after SEP-58 block:
+
+```python
+if "sep-45" in settings.ACTIVE_SEPS:
+    toml_dict["WEB_AUTH_FOR_CONTRACTS_ENDPOINT"] = os.path.join(settings.HOST_URL, "sep45", "auth")
+    toml_dict["WEB_AUTH_CONTRACT_ID"] = settings.SEP45_WEB_AUTH_CONTRACT_ID
+    # SIGNING_KEY already set by SEP-10 block (line 80). If SEP-10 is not active but SEP-45 is:
+    if "sep-10" not in settings.ACTIVE_SEPS:
+        toml_dict["SIGNING_KEY"] = settings.SIGNING_KEY
+```
+
+---
+
+### 2.10 CORS
+
+**File:** `polaris/cors.py:4-13` — add to allowed paths:
+
+```python
+or request.path.startswith("/sep45")
+```
+
+**File:** `polaris/middleware.py:62-70` — add to `SEP24_URLS` if SEP-45 interactive flows exist (unlikely for now, skip).
+
+---
+
+## Phase 3: Downstream SEP Updates
+
+Accept `C...` accounts in SEP-6, SEP-24, SEP-12, SEP-38.
+
+---
+
+### 3.1 SEP-6 deposit — accept `C...` in account parameter
+
+**File:** `polaris/sep6/deposit.py:162-171`
+
+Current code validates the `account` request param:
+```python
+if account.startswith("M"):
+    StrKey.decode_muxed_account(account)
+else:
+    Keypair.from_public_key(account)  # ← FAILS for C...
+```
+
+Fix — add `C...` branch:
+```python
+if account.startswith("M"):
+    StrKey.decode_muxed_account(account)
+elif account.startswith("C"):
+    Address(account)  # validate contract address
+else:
+    Keypair.from_public_key(account)
+```
+
+Same fix at **line 331-332** (account creation support check).
+
+---
+
+### 3.2 SEP-6 withdraw — accept `C...` in account parameter
+
+**File:** `polaris/sep6/withdraw.py:162-171`
+
+Same pattern as deposit. Add `C...` branch.
+
+---
+
+### 3.3 SEP-24 deposit — accept `C...` destination account
+
+**File:** `polaris/sep24/deposit.py:475-484`
+
+Current code:
+```python
+if destination_account.startswith("M"):
+    stellar_account = StrKey.decode_muxed_account(destination_account).ed25519
+elif:
+    Keypair.from_public_key(destination_account)  # ← FAILS for C...
+```
+
+Fix — add `C...` branch:
+```python
+if destination_account.startswith("M"):
+    ...
+elif destination_account.startswith("C"):
+    Address(destination_account)  # validate contract address
+else:
+    Keypair.from_public_key(destination_account)
+```
+
+---
+
+### 3.4 SEP-24 withdraw — accept `C...` source account
+
+**File:** `polaris/sep24/withdraw.py:468-477`
+
+Same pattern. Add `C...` branch.
+
+---
+
+### 3.5 SEP-24 interactive flow — verify `C...` handling
+
+**File:** `polaris/sep24/utils.py:134-144`
+
+Current code:
+```python
+if jwt_dict["sub"].startswith("M"):
+    muxed_account = jwt_dict["sub"]
+    stellar_account = MuxedAccount.from_account(muxed_account).account_id
+    account_memo = None
+elif ":" in jwt_dict["sub"]:
+    stellar_account, account_memo = jwt_dict["sub"].split(":")
+    muxed_account = None
+else:
+    stellar_account = jwt_dict["sub"]
+    account_memo = None
+    muxed_account = None
+```
+
+This **accidentally works** for `C...` (falls through to `else` branch). But add an explicit branch for clarity and future safety:
+
+```python
+if jwt_dict["sub"].startswith("M"):
+    ...
+elif jwt_dict["sub"].startswith("C"):
+    stellar_account = jwt_dict["sub"]
+    account_memo = None
+    muxed_account = None
+elif ":" in jwt_dict["sub"]:
+    ...
+else:
+    ...
+```
+
+**File:** `polaris/sep24/utils.py:290-305` — `generate_interactive_jwt()`
+
+Works for `C...` (memo is None, so `sub` = `"C..."`). No change needed. Add comment for clarity.
+
+---
+
+### 3.6 SEP-12 customer — no code change needed
+
+`polaris/sep12/customer.py` passes `token.muxed_account or token.account` to integration callbacks. For `C...` tokens, `muxed_account` is `None`, so `token.account` (the `C...` address) is passed. Works correctly.
+
+Anchor-implementors may need to update their `CustomerIntegration` to handle `C...` identities. Document this.
+
+---
+
+### 3.7 SEP-38 — no code change needed
+
+`polaris/sep38/prices.py` and `polaris/sep38/quote.py` use the token for authorization but don't validate account format. Works after Phase 1 rename.
+
+---
+
+### 3.8 SEP-31 — defer
+
+Current SEP-31 spec is less explicit about SEP-45 than SEP-6/24/38. Defer unless concrete interop need arises.
+
+---
+
+## Phase 4: Hardening and Tests
+
+---
+
+### 4.1 Tests — unit tests for `WebAuthToken`
+
+**New file:** `polaris/tests/webauth/test_token.py`
+
+Test cases:
+- `C...` address in `sub` → `is_contract_account == True`, `muxed_account == None`, `memo == None`
+- `G...` address in `sub` → backward compatible with existing behavior
+- `M...` address in `sub` → backward compatible
+- `G...:memo` in `sub` → backward compatible
+- Invalid `C...` → `ValueError`
+- Expired token → `ValueError`
+- Missing required claims → `ValueError`
+
+---
+
+### 4.2 Tests — nonce model
+
+**New file:** `polaris/tests/webauth/test_nonce.py`
+
+Test cases:
+- Issue and consume → success
+- Consume same nonce twice → second returns False (atomic)
+- Consume expired nonce → returns False
+- Consume with wrong account → returns False
+- **Concurrent consume** — two threads race to consume same nonce, only one succeeds
+
+---
+
+### 4.3 Tests — SEP-45 GET endpoint
+
+**New file:** `polaris/tests/sep45/test_challenge.py`
+
+**Malformed request shape:**
+- Missing `account` → 400
+- Non-`C...` account (e.g. `G...`) → 400
+- Invalid `C...` address (bad checksum) → 400
+- Missing `home_domain` → 400
+- Invalid `home_domain` → 400
+- Invalid `client_domain` hostname → 400
+- `client_domain` TOML fetch failure → 400
+- `client_domain` missing SIGNING_KEY → 400
+
+**Home-domain normalization** (Anchor Platform [PR #1774](https://github.com/stellar/anchor-platform/pull/1774)):
+- `example.com` vs `https://example.com` → both match if configured as `example.com`
+- `example.com:443` → matches `example.com` (default HTTPS port stripped)
+- `localhost:8080` → matches `localhost:8080` (non-default port preserved)
+- Wildcard `*.example.com` matches `sub.example.com` but not `example.com`
+
+**Happy path:**
+- Valid request → 200 with `authorization_entries` and `network_passphrase`
+- Valid request with `client_domain` → 200 with entries including client-domain signer entry
+
+**RPC failure modes** (Anchor Platform [PR #1904](https://github.com/stellar/anchor-platform/pull/1904)):
+- RPC unreachable → **503** with `Retry-After` header, not 500
+- RPC returns error on simulation → 502 with descriptive error
+- Authenticated RPC provider with correct headers → 200 (verify headers actually propagate)
+- Authenticated RPC provider with missing/wrong headers → 503 (not silent failure)
+
+---
+
+### 4.4 Tests — SEP-45 POST endpoint
+
+**New file:** `polaris/tests/sep45/test_token_exchange.py`
+
+**Malformed/oversized XDR:**
+- Empty `authorization_entries` → 400
+- Oversized payload (> 100KB) → 400
+- Invalid base64 → 400
+- Invalid XDR (corrupted bytes) → 400
+- Extra bytes after XDR → 400
+- Truncated XDR → 400
+
+**Args mismatch across entries:**
+- All entries identical args → pass
+- One entry has different `account` arg → 400
+- One entry has extra arg → 400
+
+**Missing/invalid server entry:**
+- Missing server auth entry entirely → 400
+- Server entry with wrong credential address → 400
+
+**Missing/invalid client-domain signer entry:**
+- `client_domain` + `client_domain_account` in args, client-domain auth entry **unsigned** (valid metadata, absent signature) → 400 (simulation ENFORCE fails)
+- `client_domain` without `client_domain_account` in args → 400
+- `client_domain_account` without `client_domain` → 400
+
+**Other protocol violations:**
+- Contract address mismatch → 400
+- Function name mismatch → 400
+- Sub-invocations present → 400
+- Missing required args → 400
+- `web_auth_domain` mismatch → 400
+- `web_auth_domain_account` mismatch → 400
+- Missing client auth entry → 400
+- Expired signature ledger → 400
+- Expired nonce → 400
+- Replayed nonce → 400
+
+**Nonce replay under concurrency:**
+- Two threads POST same nonce simultaneously → exactly one gets 200, the other gets 400
+
+**Expired signature ledger:**
+- Signature expiration ledger < current ledger → 400 with clear error message ("authorization entry signature has expired")
+
+**ENFORCE simulation failure:**
+- Invalid client signature → 400 (simulation fails)
+
+**JWT claims validation:**
+- Successful token → verify `iss` is a URI (e.g. `https://anchor.example.com`), not a bare hostname
+- Successful token → verify `sub` is the `C...` account from args
+- Successful token → verify `home_domain` claim matches request
+- Successful token → verify `client_domain` claim present iff `client_domain` was in challenge
+- Successful token → verify `jti` is SHA-256 hex of the entries payload
+- Successful token → verify `exp` = `iat` + `SEP45_JWT_TIMEOUT`
+- Successful token → verify signed with `SEP45_JWT_SECRET`, NOT `SERVER_JWT_KEY`
+
+**Content-type and CORS** (SEP-45 spec requires both POST formats):
+- `Content-Type: application/json` with JSON body → 200
+- `Content-Type: application/x-www-form-urlencoded` with form body → 200
+- `OPTIONS /sep45/auth` → proper preflight response with `Access-Control-Allow-Origin: *`
+- `Access-Control-Allow-Origin: *` header present on **error** responses (400, 503), not just success
+
+**Extra auth entries policy** (architecture doc Section 11.1):
+If the contract's `__check_auth` produces additional auth entries beyond the three specified types (client, server, client-domain), behavior must be deterministic. **Policy decision: accept extra entries** if they call the same contract with identical args, reject if they call a different contract or have different args. Test both cases.
+
+---
+
+### 4.5 Tests — mixed SEP-10/SEP-45 bearer handling
+
+**New file:** `polaris/tests/webauth/test_mixed_auth.py`
+
+These test the shared auth surface with two authenticator types on the same endpoints:
+
+**Same endpoint accepts both token types:**
+- SEP-6 `/sep6/deposit` with valid SEP-10 JWT (`G...` sub) → 200
+- SEP-6 `/sep6/deposit` with valid SEP-45 JWT (`C...` sub) → 200
+- SEP-12 `/kyc/customer` GET with SEP-10 JWT → 200
+- SEP-12 `/kyc/customer` GET with SEP-45 JWT → 200
+- SEP-38 `/sep38/quote` with SEP-10 JWT → 200
+- SEP-38 `/sep38/quote` with SEP-45 JWT → 200
+- Invalid JWT (wrong secret) → 403 from both paths
+- Expired SEP-45 JWT → 403
+
+**Ownership isolation across G... and C... identities:**
+- Create transaction with SEP-45 JWT (C... account) → success
+- Query that transaction with SEP-10 JWT (G... account for different user) → not found / 403
+- Query that transaction with SEP-10 JWT for an account that happens to share a name → not found (C... and G... are different namespaces)
+- Create transaction with SEP-10 JWT → query with SEP-45 JWT → not found
+
+---
+
+### 4.6 Tests — downstream SEP-6/24 with `C...` token
+
+Add test cases to existing test files verifying:
+- SEP-6 deposit with `C...` in `account` request param → accepted (not rejected by `Keypair.from_public_key`)
+- SEP-6 withdraw with `C...` in `account` request param → accepted
+- SEP-24 deposit with `C...` destination account → accepted
+- SEP-24 withdraw with `C...` source account → accepted
+- SEP-24 interactive flow session: `C...` stored in `session["account"]`, transaction lookup works
+- Transaction lookup filters: `stellar_account=C...` returns correct rows
+
+---
+
+### 4.7 Tests — skip when RPC unavailable
+
+```python
+@pytest.mark.skipif(
+    not os.getenv("SOROBAN_RPC_URL"),
+    reason="SOROBAN_RPC_URL not set"
+)
+class TestSEP45Integration:
+    ...
+```
+
+Pattern from Anchor Platform [commit 1e0a79e6](https://github.com/stellar/anchor-platform/commit/1e0a79e655c64b990d17c07f5ebe289bd8812db0).
+
+---
+
+### 4.8 Tests — startup and health check
+
+- SEP-45 active with missing `SOROBAN_RPC_URL` → `ImproperlyConfigured` at startup
+- SEP-45 active with missing `SEP45_WEB_AUTH_CONTRACT_ID` → `ImproperlyConfigured` at startup
+- SEP-45 active with missing `SEP45_JWT_SECRET` → `ImproperlyConfigured` at startup
+- SEP-45 active with invalid `C...` contract ID → `ImproperlyConfigured` at startup
+- SEP-45 active with `SEP45_JWT_SECRET` < 32 bytes → `ImproperlyConfigured` at startup
+- RPC health check endpoint (if implemented) returns status when RPC is reachable
+- RPC health check returns degraded status when RPC is unreachable
+
+---
+
+### 4.9 Logging
+
+Add structured logging to all SEP-45 endpoints. **Log a nonce digest, not the raw nonce** — the raw nonce is a replay token and must not appear in logs (architecture doc Section 16, anchor-platform memo Section 8).
+
+```python
+import hashlib
+
+def nonce_digest(nonce: str) -> str:
+    return hashlib.sha256(nonce.encode()).hexdigest()[:12]
+
+logger.info(
+    "SEP45 challenge account=%s home=%s client_domain=%s nonce_id=%s",
+    account, home_domain, client_domain or "-", nonce_digest(nonce)
+)
+logger.info(
+    "SEP45 auth=ok account=%s home=%s nonce_id=%s rpc_ms=%d",
+    account, home_domain, nonce_digest(nonce_value), rpc_duration_ms
+)
+logger.warning(
+    "SEP45 auth=fail account=%s nonce_id=%s reason=%s",
+    account, nonce_digest(nonce_value), error_message
+)
+```
+
+Never log: signing seeds, JWT secrets, raw JWTs, full auth entries, client-domain signing keys.
+
+---
+
+## Checklist Summary
+
+| Step | Description | Files touched | Risk |
+|---|---|---|---|
+| 1.1 | Add `"sep-45"` to accepted_seps | `settings.py` | Trivial |
+| 1.2 | SEP-45 settings + startup validation | `settings.py` | Low |
+| 1.3 | `WebAuthToken` base class | New `webauth/token.py`, update `sep10/token.py` | Medium |
+| 1.4 | Rename auth decorator | `sep10/utils.py` | Low |
+| 1.5 | Update type hints (21 files) | All SEP view + integration files | Medium (many files, mechanical) |
+| 1.6 | Transaction model docstrings | `models.py` | Trivial |
+| 2.1 | `WebAuthNonce` model | New `webauth/models.py` + migration | Low |
+| 2.2 | Nonce cleanup command | New management command | Trivial |
+| 2.3 | Client-domain helper | New `webauth/client_domain.py` | Medium (trust boundary) |
+| 2.4 | GET /sep45/auth | New `sep45/views.py` | High (Soroban XDR, simulation) |
+| 2.5 | POST /sep45/auth | Same file | High (validation, ENFORCE sim) |
+| 2.6 | XDR encode/decode | New `sep45/xdr_utils.py` | Medium (attack surface) |
+| 2.7 | Domain normalization + matching | New `sep45/utils.py` | Medium (authority comparison, not raw string) |
+| 2.8 | URL routing | `urls.py`, new `sep45/urls.py` | Trivial |
+| 2.9 | TOML update | `sep1/views.py` | Trivial |
+| 2.10 | CORS | `cors.py` | Trivial |
+| 3.1-3.2 | SEP-6 `C...` support | `sep6/deposit.py`, `sep6/withdraw.py` | Low |
+| 3.3-3.4 | SEP-24 `C...` support | `sep24/deposit.py`, `sep24/withdraw.py` | Low |
+| 3.5 | SEP-24 interactive flow | `sep24/utils.py` | Low (works by accident, add clarity) |
+| 4.1-4.2 | Token + nonce unit tests | New test files | Low |
+| 4.3 | GET endpoint tests (incl. RPC failure, domain normalization) | New test file | Medium |
+| 4.4 | POST endpoint tests (incl. JWT claims, CORS, form-encoded, extra entries) | New test file | Medium |
+| 4.5 | Mixed SEP-10/SEP-45 bearer + ownership isolation | New test file | Medium |
+| 4.6 | Downstream SEP-6/24 with C... | Existing test files | Low |
+| 4.7 | Skip-when-no-RPC guard | Test config | Trivial |
+| 4.8 | Startup config validation tests | New test file | Low |
+| 4.9 | Logging (nonce digest, not raw nonce) | `sep45/views.py` | Low |

--- a/docs/sep45/sep-45-findings.md
+++ b/docs/sep45/sep-45-findings.md
@@ -1,0 +1,461 @@
+# SEP-45 Findings
+
+## Scope
+
+This memo summarizes SEP-45 for a team building primarily in Django Polaris / Python, using the Stellar Anchor Platform Java/Kotlin implementation as a reference model.
+
+It focuses on:
+
+1. What SEP-45 is and the problem it solves
+2. How it fits into the broader Stellar SEP ecosystem
+3. How Anchor Platform implemented it
+4. What changed over time in the protocol and reference implementations
+5. What architectural and security lessons matter for a Python implementation
+
+## Executive Summary
+
+SEP-45 is the contract-account counterpart to SEP-10. It solves web authentication for `C...` accounts by replacing classic transaction-signature proof with Soroban authorization entries plus simulation against a `web_auth_verify` contract.
+
+The Java/Kotlin Anchor Platform is a useful reference for service boundaries, config, persistence, and integration testing. It is not a complete substitute for the current SEP-45 draft, because some validation in Anchor Platform is lighter than the current draft and lighter than the local Python reference implementation.
+
+The main implementation lesson is simple: treat SEP-45 as its own protocol surface, not as a small SEP-10 variation. The risk is in structural validation, nonce lifecycle, JWT semantics, and replay resistance.
+
+## What SEP-45 Is
+
+- SEP-45 is currently a `Draft` SEP, version `0.1.1`, updated `2025-12-16`, titled "Stellar Web Authentication for Contract Accounts".
+- It exists because SEP-10 only authenticates `G...` and `M...` accounts. Contract accounts (`C...`) authenticate through Soroban auth, not standard Stellar account signatures.
+- Discovery still uses SEP-1. The client reads `stellar.toml` and finds:
+  - `WEB_AUTH_FOR_CONTRACTS_ENDPOINT`
+  - `WEB_AUTH_CONTRACT_ID`
+  - `SIGNING_KEY`
+- The flow is:
+  1. Client requests a challenge
+  2. Server returns `SorobanAuthorizationEntries`
+  3. Client verifies structure and verifies the server-signed entry
+  4. Client signs the contract-account auth entry
+  5. Client simulates to ensure no unintended side effects
+  6. Client posts signed entries back
+  7. Server validates and simulates
+  8. Server issues a JWT
+
+Conceptually, SEP-45 reuses the web-session model of SEP-10, but the proof of control shifts from signing a challenge transaction to satisfying Soroban authorization rules for a contract account.
+
+## What Problem It Solves
+
+Without SEP-45, an anchor can authenticate classic Stellar accounts but has no standard way to authenticate a Soroban contract account for web APIs such as:
+
+- SEP-12 customer/KYC flows
+- SEP-24 interactive flows
+- SEP-6 deposit and withdrawal flows
+
+SEP-45 provides a standard session-establishment mechanism for those contract accounts.
+
+## Position In The SEP Ecosystem
+
+SEP-45 is complementary to SEP-10, not a replacement.
+
+- SEP-1 provides discovery.
+- SEP-10 remains the standard for classic accounts.
+- SEP-45 covers contract accounts.
+- SEP-12 can consume the resulting authenticated session.
+- SEP-24 and SEP-6 use the resulting authenticated session for deposit and withdrawal workflows.
+
+One practical product implication surfaced in Anchor Platform's release history: early contract-account support limited some withdrawal correlation because memo-based account multiplexing was not available in the same way. That is a product and state-model concern, not just an auth concern.
+
+## Key Protocol Mechanics
+
+### Discovery
+
+The client reads `stellar.toml` and learns:
+
+- the auth endpoint
+- the verifier contract ID
+- the server signing key
+
+### Challenge Construction
+
+The server simulates a call to `web_auth_verify` and obtains authorization entries. It signs the server-owned auth entry and returns the serialized entries to the client.
+
+### Client Verification
+
+The draft requires the client to verify at least:
+
+- no sub-invocations
+- correct contract ID
+- function name is `web_auth_verify`
+- argument consistency across all entries
+- presence and validity of the server auth entry
+- optional client-domain entry if requested
+- simulated ledger footprint is limited to nonce-related effects plus archived-contract restoration when needed
+
+### Server Verification
+
+The server must validate the returned entries and simulate again in enforcement mode before issuing a JWT.
+
+### Optional Client-Domain Verification
+
+If `client_domain` is present, the server may fetch the client domain's `SIGNING_KEY` from SEP-1 and require an additional auth entry. This lets the anchor attribute a session not only to an account, but also to wallet software.
+
+## Local Reference Implementation In This Repo
+
+The repo contains a local SEP-45 draft copy in [docs/sep-45.rst](/home/antb2/dev/rsync/django-polaris-bpv/docs/sep-45.rst) and a standalone reference repository under [sep45-reference/](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference).
+
+Important local reference pieces:
+
+- Python service:
+  [sep45-reference/python-sep45/sep45_server.py](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/python-sep45/sep45_server.py)
+- Python tests:
+  [sep45-reference/python-sep45/test_sep45_server.py](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/python-sep45/test_sep45_server.py)
+- Reference contracts:
+  [sep45-reference/contracts/web_auth/src/lib.rs](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/contracts/web_auth/src/lib.rs)
+  [sep45-reference/contracts/account/src/lib.rs](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/contracts/account/src/lib.rs)
+- Earlier TypeScript prototype:
+  [sep45-reference/server/challenge.ts](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/server/challenge.ts)
+
+### What The Local Python Reference Gets Right
+
+The local Python service is useful because it explicitly validates more protocol invariants before simulation than the earlier TypeScript prototype. In particular it checks:
+
+- contract account format
+- allowed home domains
+- `web_auth_domain`
+- `web_auth_domain_account`
+- consistent argument maps across entries
+- required argument presence
+- required auth-entry presence
+- sub-invocation rejection
+- expired `signature_expiration_ledger`
+- nonce one-time use
+- simulation after structural validation
+
+That is closer to what a production Python implementation should do.
+
+### What The Reference Contracts Actually Enforce
+
+Both the local reference contract and the Anchor Platform contract are intentionally small. The `web_auth_verify` contract mostly does this:
+
+- `account.require_auth()`
+- `web_auth_domain_account.require_auth()`
+- optional `client_domain_account.require_auth()`
+
+This is important architecturally: many semantic checks live in the service, not in the contract. The contract proves required parties authorized the invocation. The web service still has to validate meaning.
+
+## How Anchor Platform Implemented SEP-45
+
+Anchor Platform added a dedicated SEP-45 surface instead of burying it inside SEP-10 code paths.
+
+Key files in upstream Anchor Platform:
+
+- Core service:
+  `core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java`
+- Controller:
+  `platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep45Controller.java`
+- Config interface:
+  `core/src/main/java/org/stellar/anchor/config/Sep45Config.java`
+- Config implementation:
+  `platform/src/main/java/org/stellar/anchor/platform/config/PropertySep45Config.java`
+- JWT type:
+  `core/src/main/java/org/stellar/anchor/auth/Sep45Jwt.java`
+- Client helper:
+  `lib-util/src/main/kotlin/org/stellar/anchor/client/Sep45Client.kt`
+- Integration tests:
+  `essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep45Tests.kt`
+- DB migration:
+  `platform/src/main/resources/db/migration/V22__web_auth_account.sql`
+
+### Anchor Platform Architectural Shape
+
+The architecture is clean and worth copying:
+
+- Thin HTTP controller
+- Core service with protocol logic
+- Dedicated config object
+- Separate nonce persistence
+- Dedicated JWT type
+- Dedicated client and integration tests
+
+### Strong Design Choices In Anchor Platform
+
+- SEP-45 was given its own service and controller
+- nonces are persisted in the database
+- transaction/account storage was generalized from SEP-10-centric naming to `web_auth_account`
+- integration tests exercise challenge, signing, validation, replay failure, and client-domain signing
+- config validation became explicit rather than implicit
+
+### Gaps Relative To The Current Draft
+
+Anchor Platform leans heavily on simulation and does not visibly enforce every current draft invariant in code as strictly as the local Python reference does.
+
+Compared with the draft and local Python reference, the Java implementation appears lighter on:
+
+- explicit contract-ID validation on every entry
+- explicit function-name checks on every entry
+- explicit sub-invocation rejection
+- explicit required-entry presence checks beyond server-signature handling
+- explicit signature-expiration-ledger validation
+
+Simulation is necessary but not sufficient. A Python implementation should keep both:
+
+- structural validation before simulation
+- simulation as final authorization proof
+
+### A Concrete Semantics Risk
+
+In the current upstream `Sep45Service`, the JWT is created with `iss = homeDomain`, not `web_auth_domain`.
+
+That is only safe when both values are identical. The draft distinguishes them. A Python implementation should not collapse those two fields casually.
+
+## Evolution Over Time
+
+### Anchor Platform Timeline
+
+- `2025-01-16`: PR [#1620](https://github.com/stellar/anchor-platform/pull/1620) added SEP-45 contracts.
+- `2025-02-06`: PR [#1623](https://github.com/stellar/anchor-platform/pull/1623) implemented SEP-45 core logic.
+  - The PR explicitly noted config was still rough.
+  - The PR also noted client-domain verification had not yet been tested.
+- `2025-02-24`: PR [#1639](https://github.com/stellar/anchor-platform/pull/1639) added SEP-45 config validation.
+- `2025-04-23`: release [`3.2.0-beta.1`](https://github.com/stellar/anchor-platform/releases/tag/3.2.0-beta.1) introduced first beta contract-account support in SEP-45, SEP-24, and SEP-6.
+- `2025-09-04`: release [`4.0.0`](https://github.com/stellar/anchor-platform/releases/tag/4.0.0) shipped broader contract-account support.
+- `2025-12-11`: PR [#1870](https://github.com/stellar/anchor-platform/pull/1870) added request validation so malformed inputs return `400` instead of falling through to `500`.
+- `2026-03-05`: PR [#1900](https://github.com/stellar/anchor-platform/pull/1900) upgraded `java-stellar-sdk` to fix XDR decode OOM risk and added a 100 KB input-size guard.
+- `2026-03-18`: PR [#1906](https://github.com/stellar/anchor-platform/pull/1906) replaced separate nonce verify/use calls with atomic `verifyAndUse()` after a TOCTOU report.
+- `2026-03-24`: release [`4.2.0`](https://github.com/stellar/anchor-platform/releases/tag/4.2.0) shipped the nonce race fix.
+
+### What These Changes Mean
+
+The change history is informative:
+
+- first implementation came before full hardening
+- config correctness had to be added after core logic
+- malformed request handling had to be added later
+- parser/OOM hardening had to be added later
+- nonce race safety had to be added later
+
+That is a clear signal for a Python implementation: input size limits, strict validation, and atomic nonce consumption are not polish. They are part of the protocol boundary.
+
+### SEP-45 Reference Repository Timeline
+
+The standalone `sep45-reference` repo evolved from prototype to something intended for verifiable deployment:
+
+- initial import into the standalone repo
+- PR [#3](https://github.com/stellar/sep45-reference/pull/3): added contract build verification workflow for SEP-55-style source verification
+- PR [#4](https://github.com/stellar/sep45-reference/pull/4): removed upgradeability so the verifier contract becomes immutable
+- PR [#5](https://github.com/stellar/sep45-reference/pull/5): updated build attestation workflow
+- release [`v0.1.3`](https://github.com/stellar/sep45-reference/releases/tag/v0.1.3) published verified Wasm on `2026-01-14`
+
+This matters because a server depending on a deployed verifier contract needs:
+
+- stable source
+- verifiable build
+- immutable deployed behavior
+
+### SEP-45 Draft Evolution
+
+The local draft notes a `0.1.1` change:
+
+- stellar-protocol PR [#1827](https://github.com/stellar/stellar-protocol/pull/1827) added handling for archived SEP-45 contract instances
+
+That changed the expected client-side footprint verification rules. A client must allow the verifier contract instance restoration footprint when the contract instance is archived.
+
+## Security Findings
+
+### 1. Nonce Consumption Must Be Atomic
+
+Anchor Platform originally had separate verify and use steps. That was later fixed with a single atomic update query.
+
+This is the clearest production lesson from the history.
+
+For Django/Polaris:
+
+- use durable storage
+- make validation and consumption one atomic operation
+- do not use a process-local in-memory nonce store in production
+
+### 2. Size Limits Must Exist Before Decode
+
+Anchor Platform added a 100 KB pre-decode size cap after an OOM issue related to XDR decoding.
+
+For Python:
+
+- cap request body size
+- cap `authorization_entries` length before base64 decode
+- reject obviously oversized inputs before parser allocation
+
+### 3. Structural Validation Must Precede Simulation
+
+The service should reject malformed or semantically inconsistent entries before calling RPC simulation.
+
+Do not rely on simulation alone to infer:
+
+- field consistency
+- domain semantics
+- function identity
+- absence of sub-invocations
+- presence of expected auth actors
+
+### 4. JWT Claims Need Careful Semantics
+
+At minimum:
+
+- `iss` should reflect the correct auth domain semantics
+- `sub` should be the `C...` account
+- `exp` should be short enough to reflect signer-set drift risk
+- optional `client_domain` should only be included when actually verified
+
+### 5. The Verifier Contract Should Be Immutable Or Official
+
+If the validator contract can change in place, the security model shifts under the service.
+
+That is why the standalone SEP-45 reference contract moved toward immutability and source-verifiable release artifacts.
+
+## State-Management Findings
+
+### Nonces
+
+Nonce state is protocol state.
+
+Required properties:
+
+- unique
+- expiring
+- one-time use
+- atomically consumed
+
+### Authenticated Account Identity
+
+Anchor Platform renamed stored fields from `sep10_account` to `web_auth_account`.
+
+That is a good design choice. It prevents classic-account assumptions from leaking into contract-account workflows.
+
+### Transaction Correlation
+
+Contract-account flows may not have the same memo-based correlation patterns as classic account flows. Product and transaction state machines need to account for that explicitly.
+
+## Testing Findings
+
+A Python implementation should have three test layers.
+
+### 1. Unit Tests
+
+Focus on:
+
+- argument extraction
+- domain validation
+- required field checks
+- malformed XDR rejection
+- oversized payload rejection
+- nonce replay rejection
+- signature-expiration-ledger checks
+
+### 2. Service/API Tests
+
+Focus on:
+
+- `GET /sep45/auth`
+- `POST /sep45/auth`
+- JSON and form-encoded POST variants
+- error-code correctness
+- JWT claims
+
+### 3. Integration Tests
+
+Use real Soroban RPC and real contracts when possible.
+
+At minimum test:
+
+- challenge generation
+- client signing
+- successful validation
+- missing client signature
+- tampered server signature
+- client-domain verification
+- replay failure
+
+Anchor Platform's end-to-end tests are a good model here.
+
+## Product / Architecture Guidance For Django Polaris
+
+### Recommended Architecture
+
+Keep SEP-45 isolated:
+
+- `sep45/service.py`
+- `sep45/views.py`
+- `sep45/config.py`
+- `sep45/jwt.py`
+- `sep45/nonces.py`
+- `sep45/tests/...`
+
+Do not bury this inside SEP-10 modules.
+
+### Recommended Validation Order
+
+One obvious control path:
+
+1. Parse request
+2. Enforce request-size limits
+3. Decode XDR
+4. Validate structure and required invariants
+5. Atomically verify-and-consume nonce
+6. Simulate with enforcement
+7. Issue JWT
+
+### Recommended Operational Defaults
+
+- short JWT lifetimes
+- durable nonce store
+- RPC timeouts and failure logging
+- concise structured logs for challenge issuance, validation failure, and JWT issuance
+
+### Recommended Data Model Choices
+
+- store authenticated account as `web_auth_account`, not `sep10_account`
+- store optional `client_domain`
+- store nonce expiry separately from used-state
+
+## Practical Recommendations
+
+If implementing SEP-45 in Django Polaris / Python:
+
+1. Use the SEP draft and the local Python reference as the main validation reference.
+2. Use Anchor Platform as the architectural reference for service boundaries, persistence, and integration tests.
+3. Treat atomic nonce consumption as mandatory.
+4. Add pre-decode payload limits from day one.
+5. Validate draft invariants explicitly before simulation.
+6. Keep `home_domain` and `web_auth_domain` semantics distinct.
+7. Prefer immutable or official verifier contracts.
+
+## Source References
+
+Local sources:
+
+- [docs/sep-45.rst](/home/antb2/dev/rsync/django-polaris-bpv/docs/sep-45.rst)
+- [sep45-reference/README.md](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/README.md)
+- [sep45-reference/python-sep45/sep45_server.py](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/python-sep45/sep45_server.py)
+- [sep45-reference/python-sep45/test_sep45_server.py](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/python-sep45/test_sep45_server.py)
+- [sep45-reference/server/challenge.ts](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/server/challenge.ts)
+- [sep45-reference/contracts/web_auth/src/lib.rs](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/contracts/web_auth/src/lib.rs)
+- [sep45-reference/contracts/account/src/lib.rs](/home/antb2/dev/rsync/django-polaris-bpv/sep45-reference/contracts/account/src/lib.rs)
+
+Upstream sources:
+
+- Anchor Platform repo: https://github.com/stellar/anchor-platform
+- SEP-45 reference repo: https://github.com/stellar/sep45-reference
+- Stellar protocol repo: https://github.com/stellar/stellar-protocol
+
+Key PRs and releases:
+
+- Anchor Platform PR [#1620](https://github.com/stellar/anchor-platform/pull/1620)
+- Anchor Platform PR [#1623](https://github.com/stellar/anchor-platform/pull/1623)
+- Anchor Platform PR [#1639](https://github.com/stellar/anchor-platform/pull/1639)
+- Anchor Platform PR [#1870](https://github.com/stellar/anchor-platform/pull/1870)
+- Anchor Platform PR [#1900](https://github.com/stellar/anchor-platform/pull/1900)
+- Anchor Platform PR [#1906](https://github.com/stellar/anchor-platform/pull/1906)
+- Anchor Platform release [`3.2.0-beta.1`](https://github.com/stellar/anchor-platform/releases/tag/3.2.0-beta.1)
+- Anchor Platform release [`4.0.0`](https://github.com/stellar/anchor-platform/releases/tag/4.0.0)
+- Anchor Platform release [`4.2.0`](https://github.com/stellar/anchor-platform/releases/tag/4.2.0)
+- SEP-45 reference PR [#3](https://github.com/stellar/sep45-reference/pull/3)
+- SEP-45 reference PR [#4](https://github.com/stellar/sep45-reference/pull/4)
+- SEP-45 reference PR [#5](https://github.com/stellar/sep45-reference/pull/5)
+- SEP-45 reference release [`v0.1.3`](https://github.com/stellar/sep45-reference/releases/tag/v0.1.3)
+- Stellar protocol PR [#1827](https://github.com/stellar/stellar-protocol/pull/1827)

--- a/docs/sep45/sep45-research-memo.md
+++ b/docs/sep45/sep45-research-memo.md
@@ -1,0 +1,569 @@
+# SEP-45 Research Memo
+
+## 1. Executive Summary
+
+SEP-45 is the contract-account analog of SEP-10. It lets a wallet authenticate to an anchor on behalf of a Soroban contract account (`C...`) by exchanging signed Soroban authorization entries for a JWT session token. It is explicitly additive, not a replacement: SEP-45 covers contract accounts, while SEP-10 still covers classic (`G...`) and muxed (`M...`) accounts. Services that want to support the full account surface need both. The SEP remains `Draft` as of December 16, 2025, so implementation should stay conservative, feature-flagged, and easy to revise. ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md), [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md))
+
+The Java/Kotlin Anchor Platform implementation is a useful reference model, but not because it is a cleanly portable design. It is useful because it shows the real implementation footprint: a new auth handshake, new config, new tests, RPC simulation dependency, shared JWT abstraction changes, database changes for nonce handling, and downstream SEP-6/24/31/38 adjustments. The Git history is the most valuable source here. Most of the important lessons arrived after the initial merge, in follow-up fixes for config validation, client-domain signer fetching, replay protection, request validation, XDR parsing hardening, RPC auth propagation, and deployment wiring. ([Anchor Platform PR #1623](https://github.com/stellar/anchor-platform/pull/1623), [Anchor Platform PR #1906](https://github.com/stellar/anchor-platform/pull/1906), [Anchor Platform 4.2.0 release](https://github.com/stellar/anchor-platform/releases/tag/4.2.0))
+
+For a Django Polaris / Python implementation, the main lesson is not "port the Java classes." The right lesson is to introduce a generic web-auth abstraction above SEP-10 and SEP-45, isolate SEP-45-specific handshake logic behind its own service layer, keep downstream SEP services dependent on a common authenticated session object, and add only the minimum new persisted state required for nonce replay prevention and operational auditability. Current upstream Polaris is still SEP-10-centric in its auth decorators, token model, TOML generation, and transaction schema, so SEP-45 support would be a real extension, not a small patch. ([Django Polaris README](https://github.com/stellar/django-polaris/blob/master/README.rst), [polaris/sep10/token.py](https://github.com/stellar/django-polaris/blob/master/polaris/sep10/token.py), [polaris/integrations/toml.py](https://github.com/stellar/django-polaris/blob/master/polaris/integrations/toml.py))
+
+## 2. What SEP-45 Is
+
+SEP-45 defines web authentication for contract accounts. Discovery still begins with SEP-1 `stellar.toml`, but the advertised fields differ from SEP-10: the client discovers `WEB_AUTH_FOR_CONTRACTS_ENDPOINT`, `WEB_AUTH_CONTRACT_ID`, and `SIGNING_KEY`. The challenge is not a classic transaction envelope. It is a set of Soroban authorization entries for a `web_auth_verify` contract function, encoded as `SorobanAuthorizationEntries`. ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md), [SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md))
+
+The actors are:
+
+- the home domain publishing `stellar.toml`
+- the anchor auth server
+- the server signing key from `SIGNING_KEY`
+- the client wallet
+- the client contract account (`C...`)
+- optionally a client domain that publishes its own `SIGNING_KEY`
+- the deployed SEP-45 web-auth contract referenced by `WEB_AUTH_CONTRACT_ID`
+
+The authentication flow, as specified, is:
+
+1. The client fetches `stellar.toml` from the home domain and discovers the SEP-45 endpoint and contract ID.
+2. The client requests a challenge from `GET <WEB_AUTH_FOR_CONTRACTS_ENDPOINT>`, including `account`, `home_domain`, and optionally `client_domain`.
+3. The server returns authorization entries for `web_auth_verify`, including common arguments such as `account`, `home_domain`, `web_auth_domain`, `web_auth_domain_account`, optional client-domain fields, and a nonce.
+4. The client verifies those entries, signs the auth entry associated with the contract account, optionally signs the client-domain entry, simulates the transaction, verifies the footprint is safe, and posts the signed entries back.
+5. The server verifies the returned entries, verifies the nonce has not been reused, simulates again, and returns a JWT token if successful. ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md))
+
+"Contract account authentication" in practice means proving that the contract account's auth logic authorizes the `web_auth_verify` invocation. This is not the same as SEP-10's proof that a user controls signing keys on a classic account. SEP-45 uses the Soroban authorization mechanism and contract-side `require_auth`, not classic threshold evaluation. ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md))
+
+SEP-45 differs from SEP-10 in several material ways:
+
+| Dimension | SEP-10 | SEP-45 |
+| --- | --- | --- |
+| Supported account types | `G...`, `M...` | `C...` |
+| Challenge format | classic transaction envelope | Soroban authorization entries |
+| Verification basis | account signers and thresholds | contract auth semantics plus simulation |
+| Replay controls | challenge tx constraints and server logic | nonce plus signature-expiration-ledger discipline |
+| Wallet responsibility | verify tx shape, signatures | verify auth entries, simulate, verify footprint |
+
+An implementation may need both because the user population is mixed. Any anchor serving both classic wallets and smart wallets needs classic-account auth and contract-account auth side by side. The SEP explicitly says SEP-45 does not replace SEP-10. ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md), [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md))
+
+## 3. Where SEP-45 Fits in the Stellar SEP Landscape
+
+SEP-45 sits in the authentication layer of the anchor stack.
+
+SEP-1 is a prerequisite because it is the discovery mechanism for `WEB_AUTH_FOR_CONTRACTS_ENDPOINT`, `WEB_AUTH_CONTRACT_ID`, and `SIGNING_KEY`. Without SEP-1 changes, SEP-45 is undiscoverable. ([SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md))
+
+SEP-10 remains the classic-account auth mechanism. The two standards are complementary. Supporting SEP-45 does not remove the need for SEP-10 if classic or muxed accounts are still supported. ([SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md), [SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md))
+
+SEP-6 and SEP-24 now explicitly allow either SEP-10 or SEP-45 JWTs and permit `C...` accounts in their request parameters. This is where SEP-45 becomes operationally important for anchors. It is not enough to issue a token; deposit, withdrawal, and transaction lookup flows must accept it and interpret the authenticated identity correctly. ([SEP-6](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md), [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md))
+
+SEP-12 is not an auth SEP, but it is downstream of auth. Contract-account authentication affects customer retrieval and update flows because the authenticated identity presented to SEP-12 may now be a contract account instead of a classic or muxed account. ([SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md))
+
+SEP-31 is more ambiguous. The current SEP-31 text still frames inter-anchor auth in SEP-10 terms, but Anchor Platform's implementation added contract-account support in downstream services. This suggests implementation latitude, but not the same specification clarity that SEP-6, SEP-24, and SEP-38 now have. That matters if a Python implementation wants to support SEP-31 with contract accounts early. ([SEP-31](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md), [Anchor Platform PR #1723](https://github.com/stellar/anchor-platform/pull/1723))
+
+SEP-38 explicitly added SEP-45 support for request authentication. In practice, this means quote and pricing APIs may need to accept either SEP-10 or SEP-45 bearer tokens and preserve enough account identity to personalize or authorize quote access. ([SEP-38](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md))
+
+The direct design implication is simple: any anchor authentication abstraction that is SEP-10-specific will become friction once SEP-45 is added. The auth layer must become "web auth" instead of "SEP-10 auth."
+
+## 4. How Anchor Platform Implements SEP-45
+
+At a high level, Anchor Platform implements SEP-45 as a dedicated auth handshake service, wired into a broader shared web-auth model.
+
+The main modules are:
+
+- `Sep45Controller` for `GET /sep45/auth` and `POST /sep45/auth`
+- `Sep45Service` for challenge generation and validation
+- `PropertySep45Config` and `Sep45Config` for settings and validation
+- `JwtService`, `Sep45Jwt`, and `WebAuthJwt` for token issuance and downstream parsing
+- `NonceManager`, `NonceStore`, and JDBC nonce persistence for replay protection
+- `StellarRpc` as the required simulation backend
+- `ClientDomainHelper` for optional client-domain signer lookup
+- downstream shared auth filter `WebAuthJwtFilter` so SEP-6/24/31/38 can accept either SEP-10 or SEP-45 bearer tokens ([Sep45Controller](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep45Controller.java), [Sep45Service](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java), [SepBeans](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java))
+
+The request flow is:
+
+1. `GET /sep45/auth` validates the incoming `account` and `home_domain`.
+2. The service constructs argument SCVals for `web_auth_verify`.
+3. It simulates an `InvokeHostFunctionOperation` against the configured web-auth contract in recording mode.
+4. It extracts the auth entries from simulation results.
+5. It signs the server-account auth entry with the SEP-10 signing seed.
+6. It returns encoded authorization entries plus `network_passphrase`. ([Sep45Service](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java))
+
+The verification flow is:
+
+1. `POST /sep45/auth` decodes returned authorization entries.
+2. It checks the entries are present and that all entries share the same arguments.
+3. It verifies the argument values, including `home_domain`, `web_auth_domain`, and optional client-domain signer resolution.
+4. It verifies the server signature if one of the entries belongs to the server account.
+5. It atomically verifies and consumes the nonce.
+6. It simulates again in enforcing mode with the submitted auth entries.
+7. If simulation succeeds, it issues a SEP-45 JWT. ([Sep45Service](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java), [NonceManager](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/auth/NonceManager.java))
+
+JWT/session handling is split sensibly. `Sep45Jwt` extends `WebAuthJwt`, and the shared filter tries to decode SEP-10 first and then SEP-45. This lets downstream SEP controllers work with a common request attribute and common account/client-domain accessors. That is a good conceptual pattern to reuse in Python. ([Sep45Jwt](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/auth/Sep45Jwt.java), [WebAuthJwt](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/auth/WebAuthJwt.java), [WebAuthJwtFilter](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/filter/WebAuthJwtFilter.java))
+
+Configuration requirements are explicit:
+
+- SEP-45 must be enabled.
+- RPC URL must be present.
+- SEP-45 JWT secret must be present.
+- home domains must be configured.
+- web-auth contract ID must be configured.
+- web-auth domain may be inferred only when there is a single non-wildcard home domain.
+- auth timeout and JWT timeout must be positive. ([PropertySep45Config](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep45Config.java), [Anchor Platform SEP-45 docs](https://developers.stellar.org/platforms/anchor-platform/sep-guide/sep45))
+
+The external dependency that changes the architecture is RPC simulation. Anchor Platform asserts that the `LedgerClient` used for SEP-45 is actually `StellarRpc`, not Horizon. This is a hard coupling to Soroban RPC behavior. ([SepBeans](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java))
+
+Inference: the handshake service itself is reasonably separable. The broader support story is not. Once SEP-45 is added, token abstractions, transaction identity fields, quote ownership checks, interactive-flow assumptions, deployment config, and tests all need attention.
+
+## 5. GitHub History and Evolution of SEP-45 Support
+
+### Initial feature introduction
+
+The first step was not the endpoint itself but the Soroban contracts used to test and exercise the flow. `PR #1620` added the web-auth contract and a test account contract. That is a useful signal: SEP-45 is contract-aware at the protocol level, so an implementation without contract fixtures and contract-version thinking is incomplete from the start. ([PR #1620](https://github.com/stellar/anchor-platform/pull/1620))
+
+`PR #1623`, merged on February 6, 2025, introduced the core SEP-45 implementation. The PR text is unusually candid and therefore valuable. It explicitly says the config was intentionally kept simple, tests and config comments were not fully implemented yet, and client-domain verification had not been tested. That is the best evidence that the first merge was not production-hard. ([PR #1623](https://github.com/stellar/anchor-platform/pull/1623))
+
+### Downstream contract-account rollout
+
+Within days, Anchor Platform had to touch downstream SEPs:
+
+- SEP-6 deposit for contract accounts in `PR #1629`
+- SEP-6 withdraw for contract accounts in `PR #1630`
+- SEP-24 deposit in `PR #1640`
+- SEP-24 withdraw in `PR #1649`
+- SEP-12 explicit contract-account support in `PR #1647`
+- SEP-38 contract-account support in `PR #1667` ([PR #1629](https://github.com/stellar/anchor-platform/pull/1629), [PR #1630](https://github.com/stellar/anchor-platform/pull/1630), [PR #1640](https://github.com/stellar/anchor-platform/pull/1640), [PR #1649](https://github.com/stellar/anchor-platform/pull/1649), [PR #1647](https://github.com/stellar/anchor-platform/pull/1647), [PR #1667](https://github.com/stellar/anchor-platform/pull/1667))
+
+This reveals the first hidden assumption: "adding SEP-45" is not an auth-only task. Any anchor implementation that treats it that way will end up with downstream flows that either reject contract accounts or mishandle identity.
+
+### Config hardening
+
+`PR #1639` added SEP-45 config validation after the core feature already existed. That included validation for RPC presence, JWT secret, home domains, contract ID format, web-auth domain rules, and timeout values. This is a predictable maturity pattern: protocol features tend to land before config validation is strict enough. A Python implementation should invert that sequence and ship hard validation first. ([PR #1639](https://github.com/stellar/anchor-platform/pull/1639))
+
+### Identity model cleanup
+
+`PR #1657` renamed `sep10_account` fields to `web_auth_account`. This is one of the clearest architectural lessons in the entire history. As soon as SEP-45 existed, SEP-10-specific field names became wrong. If Django Polaris introduces SEP-45 support without first generalizing the identity model, it will create the same debt. ([PR #1657](https://github.com/stellar/anchor-platform/pull/1657))
+
+### JWT secret separation
+
+`PR #1659` changed SEP-45 JWT encoding and decoding to use a dedicated SEP-45 secret instead of the SEP-10 secret. That is a straightforward boundary correction. Reusing the same secret across auth mechanisms is unnecessary coupling and makes rotation and blast-radius management worse. The Python design should use a separate secret from day one. ([PR #1659](https://github.com/stellar/anchor-platform/pull/1659))
+
+### Client-domain verification and trust model changes
+
+`PR #1673` added SEP-45 client-domain verification tests. The current `Sep45Client` and integration tests show two important cases: successful verification when the client-domain signer signs, and rejection when that signature is missing. This confirms client-domain support is optional but semantically meaningful. ([PR #1673](https://github.com/stellar/anchor-platform/pull/1673), [Sep45Tests](https://github.com/stellar/anchor-platform/blob/develop/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep45Tests.kt))
+
+The trust model then changed again. The history for `ClientDomainHelper` shows `PR #1865`, "Fetch client domain signer over HTTPS", merged on December 3, 2025. Before that, the helper had briefly been switched to HTTP in `PR #1673` to make tests work. The later fix restored HTTPS and only allows HTTP retry outside pubnet by checking the network passphrase. That sequence teaches two things:
+
+- signer discovery is a real security boundary, not a convenience lookup
+- test convenience can create silent production trust regressions if not corrected promptly ([PR #1865](https://github.com/stellar/anchor-platform/pull/1865), [ClientDomainHelper](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java))
+
+### Replay protection and nonce handling
+
+`PR #1676` added nonce generation, persistence, cleanup, and validation. This created nonce models, JDBC storage, cleanup jobs, and tests. The important lesson is that replay protection became a database concern, not just a protocol concern. The SEP talks about nonce uniqueness and expiration, but production implementation required explicit persistence and scheduled cleanup. ([PR #1676](https://github.com/stellar/anchor-platform/pull/1676), [NonceCleanupJob](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/java/org/stellar/anchor/platform/job/NonceCleanupJob.java))
+
+That was still not enough. On March 18, 2026, `PR #1906` fixed a SEP-45 nonce TOCTOU race condition after a HackerOne report. The patch replaced separate verify/use semantics with atomic `verifyAndUse()` backed by a single SQL update predicate `used=false AND expires_at > now`. This is the strongest evidence in the history that replay protection must be atomic at the persistence layer. A Django implementation should not ship a two-step verify-then-mark flow. ([PR #1906](https://github.com/stellar/anchor-platform/pull/1906), [JdbcNonceRepo](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/java/org/stellar/anchor/platform/data/JdbcNonceRepo.java))
+
+### Simulation/config simplification
+
+`PR #1697` removed `SEP45_SIMULATING_SIGNING_SEED`. Earlier versions assumed a separate signing seed was needed for simulation. The follow-up removed that config and switched to a random account as the simulation source. This is a good example of configuration load that turned out to be unnecessary. For Python, avoid introducing configuration unless it is proven necessary. ([PR #1697](https://github.com/stellar/anchor-platform/pull/1697))
+
+### Contract-version and compatibility churn
+
+`PR #1702` updated argument names for the contract from `home_domain_address` / `client_domain_address` to `web_auth_domain_account` / `client_domain_account` and added contract metadata fields `sep` and `version`. This shows that even the reference contract interface was still moving. A Python implementation must expect versioning and compatibility checks around the contract ID and contract semantics. ([PR #1702](https://github.com/stellar/anchor-platform/pull/1702), [web-auth contract](https://github.com/stellar/anchor-platform/blob/develop/soroban/contracts/web-auth/src/lib.rs))
+
+### Test-environment and rollout friction
+
+The integration tests had to be explicitly skipped when `stellar_network.rpc_url` was not set (`commit 1e0a79e6`). Later PRs enabled SEP-45 in dev env (`PR #1766`) and fixed the Helm chart so the SEP-45 JWT secret actually reached deployments (`PR #1767`). This is operationally important. SEP-45 is not just code plus tests. It is code plus RPC infrastructure plus deployment secrets plus a credible local/dev path. ([commit 1e0a79e6](https://github.com/stellar/anchor-platform/commit/1e0a79e655c64b990d17c07f5ebe289bd8812db0), [PR #1766](https://github.com/stellar/anchor-platform/pull/1766), [PR #1767](https://github.com/stellar/anchor-platform/pull/1767))
+
+### Interoperability and validation fixes
+
+`PR #1774` normalized home-domain comparison so that values like `example.com`, `localhost:8080`, and `https://example.com` would compare on authority rather than exact string form. This reveals a classic implementation trap: domain values from wallets, config, and TOML are rarely normalized the same way. Do not compare raw strings. ([PR #1774](https://github.com/stellar/anchor-platform/pull/1774))
+
+`PR #1870` added basic request validation because malformed requests were falling through to internal server errors. Specifically, the service added checks for missing `account`, non-contract `account`, missing `home_domain`, missing `authorization_entries`, and empty decoded auth-entry sets. This is a maturity signal: even if the protocol is correct, request-shape hardening often gets postponed until after bad traffic hits real servers. ([PR #1870](https://github.com/stellar/anchor-platform/pull/1870))
+
+### XDR/SDK evolution
+
+`commit eb383978` replaced a local `SorobanAuthorizationEntryList` wrapper with the SDK's `SorobanAuthorizationEntries` type. This indicates underlying SDK/XDR model movement and a shift toward official types. A Python implementation should avoid inventing local wrappers unless the SDK truly cannot express the required shape. ([commit eb383978](https://github.com/stellar/anchor-platform/commit/eb3839787dcae5aa2b7c55cc54714cf2894801d5))
+
+### Security hardening in 2026
+
+`PR #1900`, merged on March 5, 2026, upgraded `java-stellar-sdk` from `2.0.0` to `2.2.3` because the SDK's XDR decoder needed a fix that validated length prefixes before allocating memory. Anchor Platform also added a 100 KB size guard on raw `authorization_entries` before decoding. This is a direct lesson for Python: treat auth-entry payload decoding as an attack surface, not as trusted protocol data. ([PR #1900](https://github.com/stellar/anchor-platform/pull/1900), [Anchor Platform 4.1.8 release](https://github.com/stellar/anchor-platform/releases/tag/4.1.8))
+
+`PR #1904`, merged on March 18, 2026, fixed a bug where configured RPC auth headers were not actually propagated into requests. Since SEP-45 is RPC-dependent, bad infra auth broke auth flows. This is not a protocol bug. It is an operational dependency bug. Python needs explicit tests for authenticated RPC providers. ([PR #1904](https://github.com/stellar/anchor-platform/pull/1904))
+
+Overall, the history teaches that the real implementation complexity lives in trust boundaries, request validation, replay protection, infrastructure auth, and downstream identity semantics, not in the happy-path controller.
+
+## 6. API / Auth / Integration Surface
+
+The public SEP-45 API surface is small:
+
+- `GET <WEB_AUTH_FOR_CONTRACTS_ENDPOINT>` to request authorization entries
+- `POST <WEB_AUTH_FOR_CONTRACTS_ENDPOINT>` to exchange signed entries for a JWT
+- downstream SEP requests continue to use `Authorization: Bearer <JWT>` ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md))
+
+The discovery surface is also small but non-negotiable:
+
+- `WEB_AUTH_FOR_CONTRACTS_ENDPOINT`
+- `WEB_AUTH_CONTRACT_ID`
+- `SIGNING_KEY` in `stellar.toml` ([SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md))
+
+Anchor Platform's service surface adds config and runtime dependencies:
+
+- `sep45.enabled`
+- `sep45.home_domains`
+- `sep45.web_auth_domain`
+- `sep45.web_auth_contract_id`
+- `sep45.auth_timeout`
+- `sep45.jwt_timeout`
+- `secret.sep45.jwt_secret`
+- `secret.sep10.signing_seed`
+- `stellar_network.rpc_url` ([Anchor Platform docs](https://developers.stellar.org/platforms/anchor-platform/sep-guide/sep45), [PropertySep45Config](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep45Config.java))
+
+The integration surface into other SEPs is through shared bearer-token handling. Anchor Platform solved this by switching to `WebAuthJwtFilter` and a shared `WebAuthJwt` abstraction. Conceptually, that is the right move. Python should do the same.
+
+Inference: the right Python integration shape is:
+
+- one bearer-token contract for downstream SEP endpoints
+- two authenticators behind it, SEP-10 and SEP-45
+- one generic authenticated identity object passed into SEP-6/24/38 logic
+- one TOML generator that can advertise both auth mechanisms
+
+Anything more fragmented will create controller-level duplication and inconsistent auth behavior.
+
+## 7. Data Model and State Implications
+
+Anchor Platform's persisted SEP-45 state is intentionally narrow:
+
+- a nonce table with `id`, `used`, and `expires_at`
+- transaction tables carrying generic authenticated identity fields and `client_domain`
+- no persistence of raw challenge authorization entries by default ([V22 migration](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/resources/db/migration/V22__web_auth_account.sql), [JdbcNonce](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/java/org/stellar/anchor/platform/data/JdbcNonce.java))
+
+That is a good default. For Django Polaris / Python, the likely persisted entities are:
+
+- `WebAuthNonce`
+  - `id`
+  - `used`
+  - `expires_at`
+  - optional `created_at`
+  - optional `used_at`
+  - optional `account`
+  - optional `home_domain`
+  - optional `client_domain`
+
+- transaction identity fields generalized away from SEP-10 assumptions
+  - authenticated account
+  - authenticated account type (`classic`, `muxed`, `contract`)
+  - authenticated memo if applicable
+  - client domain
+  - optional auth mechanism (`sep10`, `sep45`)
+
+- optional audit/event model
+  - request id
+  - auth mechanism
+  - endpoint
+  - account
+  - client domain
+  - nonce id or nonce digest
+  - simulation status
+  - failure reason
+  - timestamps
+
+The practical split should be:
+
+- persisted state for replay prevention and operations
+- derived/transient state for auth-entry content, simulation results, and JWT parsing
+
+Do not persist raw JWTs. Do not persist raw authorization entries unless there is a strong forensic requirement. If auditability is needed, store a digest and structured metadata instead.
+
+For current Polaris specifically, the data model is still centered on `stellar_account`, `muxed_account`, and `account_memo`, with docstrings that explicitly describe SEP-10-authenticated classic accounts. That is serviceable for classic flows but awkward for contract-account support. It strongly suggests either:
+
+- adding new generic web-auth fields and migrating call sites, or
+- wrapping the existing fields with a new abstraction while introducing a contract-account extension model
+
+The first option is architecturally cleaner. ([polaris/models.py](https://github.com/stellar/django-polaris/blob/master/polaris/models.py))
+
+## 8. Security, Compliance, and Operational Concerns
+
+### Trust boundaries
+
+SEP-45 adds more trust boundaries than SEP-10:
+
+- the wallet's verification of server intent
+- the anchor's verification of contract authorization
+- the optional client-domain signer lookup
+- the trustworthiness and availability of the RPC provider
+- the correctness and version of the deployed web-auth contract
+- the JWT signing and verification secret material ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md))
+
+### Attack surfaces
+
+Replay risk is the clearest one. The spec requires nonce handling and recommends signature-expiration-ledger discipline. Anchor Platform's post-release TOCTOU fix proves that nonce persistence alone is insufficient if consume semantics are not atomic. ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md), [PR #1906](https://github.com/stellar/anchor-platform/pull/1906))
+
+Signature verification risk exists in both server and client directions:
+
+- the wallet must verify the server-auth entry is actually signed by the discovered server account
+- the server must verify its own signed entry and trust simulation to validate the rest
+- if client-domain verification is enabled, both sides must agree on the correct `SIGNING_KEY`
+
+Client-domain fetching is a real attack surface. The history shows an implementation regression from HTTPS to HTTP and then a fix back to HTTPS. Production Python should:
+
+- use HTTPS by default
+- fail closed on pubnet
+- make any HTTP fallback explicit and non-production only
+- bound response size and redirect count for TOML fetching ([PR #1865](https://github.com/stellar/anchor-platform/pull/1865), [Anchor Platform 4.1.8 release](https://github.com/stellar/anchor-platform/releases/tag/4.1.8))
+
+RPC simulation responses are another fragility source. If the RPC provider requires auth, incorrect header propagation can break all SEP-45 auth. If the provider is slow or inconsistent, SEP-45 auth latency becomes infrastructure-bound. If the SDK parser is weak, malformed auth-entry payloads become a denial-of-service vector. ([PR #1900](https://github.com/stellar/anchor-platform/pull/1900), [PR #1904](https://github.com/stellar/anchor-platform/pull/1904))
+
+### JWT issuance and expiry
+
+Short JWT lifetimes are preferable. The spec notes that account control can change after issuance. For contract accounts, the same principle applies, and arguably more so, because contract auth rules may change in ways the anchor does not observe directly. ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md))
+
+### Logging
+
+What must never be logged:
+
+- signing seeds
+- JWT secrets
+- raw JWTs
+- full raw authorization entries
+- client-domain secrets
+
+What should be logged:
+
+- account identifier
+- auth mechanism
+- home domain
+- client domain if present
+- nonce id or digest
+- simulation success/failure
+- rejection reason
+- RPC provider class or URL host
+- request correlation id
+
+Anchor Platform's own logging style is concise and factual, which is the right pattern to follow.
+
+### Production controls
+
+Operational controls worth carrying into Python:
+
+- feature-flag SEP-45 separately from SEP-10
+- health checks for RPC reachability
+- startup config validation for all required keys and domains
+- strict input size limits on auth-entry payloads
+- atomic nonce consumption
+- clear pubnet vs non-pubnet client-domain fetch policy
+- metrics on auth success, auth failure, nonce reuse, simulation latency, TOML fetch failures, and RPC auth failures
+
+## 9. UX / Product Implications
+
+SEP-45 changes product behavior for smart wallets because the wallet must understand Soroban auth entries, not just sign a challenge transaction. A compliant wallet should verify the challenge semantics and perform its own simulation and footprint checks. That is more demanding than SEP-10 and will create more wallet-side failure modes. ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md))
+
+For anchors, the biggest product shift is that "authenticated user identity" is no longer synonymous with a classic account plus optional memo. This matters for KYC reuse, transaction grouping, rate personalization, and support tools.
+
+For support teams, the confusing failure cases will be:
+
+- unsupported or malformed home domain
+- invalid contract account format
+- client-domain signer fetch failure
+- missing client-domain signature
+- expired or reused nonce
+- expired signature ledger
+- RPC outage or unauthorized RPC
+- wallet signed the wrong network passphrase
+
+For admin teams, the operational questions become:
+
+- which wallets are using SEP-45 successfully
+- which client domains are presenting themselves
+- whether the deployed contract ID is consistent across environments
+- whether a failure is caused by the wallet, TOML hosting, RPC, or anchor logic
+
+Mixed SEP-10 + SEP-45 support should be presented as account-type-dependent behavior, not as two products. A user with a classic account should experience normal SEP-10. A user with a smart wallet should discover and use SEP-45. The product should avoid forcing users to choose an auth mechanism manually whenever possible.
+
+One specific product limitation surfaced in Anchor Platform's `3.2.0-beta.1` release notes: because memos are not part of SEP-45 semantics, SEP-6 and SEP-24 withdrawals were limited to one ongoing transaction per account. That is a concrete reminder that protocol identity semantics can leak directly into product constraints. A Python implementation should identify those cases early and decide whether to accept them, redesign around them, or delay the feature. ([Anchor Platform 3.2.0-beta.1 release](https://github.com/stellar/anchor-platform/releases/tag/3.2.0-beta.1))
+
+## 10. Translation to Django Polaris / Python
+
+This is the most important section.
+
+Current upstream Django Polaris does not appear to have first-class SEP-45 support. The official README still says Polaris supports SEP-1, 6, 10, 12, 24, 31, and 38. The code tree has no SEP-45 module. The SEP-1 TOML integration only lists `WEB_AUTH_ENDPOINT` among default auth-related fields. The token abstraction is `SEP10Token`, and the validation decorator is `validate_sep10_token()`. The `Transaction` model is documented in explicitly SEP-10-centric terms. There are no SEP-45 mentions in current official releases. ([README.rst](https://github.com/stellar/django-polaris/blob/master/README.rst), [polaris/integrations/toml.py](https://github.com/stellar/django-polaris/blob/master/polaris/integrations/toml.py), [polaris/sep10/utils.py](https://github.com/stellar/django-polaris/blob/master/polaris/sep10/utils.py), [polaris/models.py](https://github.com/stellar/django-polaris/blob/master/polaris/models.py), [Django Polaris releases](https://github.com/stellar/django-polaris/releases))
+
+That means SEP-45 support in Polaris is not a small extension. It is an architectural addition.
+
+### What is worth copying conceptually from Anchor Platform
+
+- A dedicated SEP-45 handshake service.
+- A shared web-auth token abstraction consumed by downstream SEP services.
+- Separate JWT secret material for SEP-45.
+- Database-backed nonce storage with atomic consume semantics.
+- Explicit RPC dependency rather than trying to fake SEP-45 through Horizon-oriented abstractions.
+- Client-domain handling as a separate helper/service with its own trust policy.
+
+### What should be simplified for Django Polaris
+
+- Avoid Spring-style bean wiring. Use a small service layer:
+  - `webauth/session.py`
+  - `webauth/sep10.py`
+  - `webauth/sep45.py`
+  - `webauth/nonces.py`
+  - `webauth/client_domain.py`
+  - `webauth/rpc.py`
+
+- Do not add a separate microservice initially. Keep it in the same Django app if SEP-45 is only used by Polaris-managed SEP endpoints.
+- Do not overbuild contract-version registries or generic policy engines. Start with one supported contract interface and explicit config.
+
+### What should likely live outside stock Polaris flows
+
+- The SEP-45 auth endpoints themselves are new.
+- Any contract-account-aware interactive-flow session logic for SEP-24 will likely need custom work because Polaris' current interactive auth/session helpers are tightly shaped around SEP-10 JWT structure and classic-account fields. ([polaris/sep24/utils.py](https://github.com/stellar/django-polaris/blob/master/polaris/sep24/utils.py))
+
+### What custom Django models or layers are likely needed
+
+- `WebAuthNonce` model
+- a generic `WebAuthSession` or `WebAuthToken` parser type
+- a `Sep45Token` parser
+- middleware or DRF auth classes that can accept either SEP-10 or SEP-45 bearer tokens
+- TOML integration override that emits `WEB_AUTH_FOR_CONTRACTS_ENDPOINT` and `WEB_AUTH_CONTRACT_ID`
+- generic transaction identity fields or adapters to remove SEP-10-only assumptions
+
+### What is a natural fit in Polaris
+
+- existing SEP-6, SEP-24, and SEP-38 endpoint structure
+- integration hook model for customer, quote, info, and rails logic
+- Django ORM for nonce persistence and audit tables
+
+### What is awkward in Polaris
+
+- the SEP-10-specific token class and decorator naming
+- the transaction model's classic-account framing
+- SEP-24 interactive helpers that assume current token/session structure
+- lack of native RPC simulation/auth service abstractions
+
+### Same service, dedicated auth service, or hybrid?
+
+The simplest robust design is a hybrid inside one deployable:
+
+- one Django service
+- one internal `webauth` module
+- one generic auth layer for downstream SEPs
+- separate endpoint modules for SEP-10 and SEP-45
+- one shared transaction/customer/quote ownership model
+
+A standalone auth microservice is unnecessary unless there is a broader platform need to share auth across multiple independently deployed services. Nothing in the current evidence suggests that is needed first.
+
+## 11. Recommended Learnings for Our Django Polaris Python Implementation
+
+### Concrete design recommendations
+
+- Introduce a generic web-auth abstraction before adding SEP-45 endpoints.
+- Add SEP-45 alongside SEP-10, not instead of SEP-10.
+- Treat RPC simulation as a first-class dependency with explicit config, health checks, and auth support.
+- Store nonces in the database and consume them atomically.
+- Keep JWTs stateless and separate SEP-45 signing secrets from SEP-10 secrets.
+- Generalize transaction and quote ownership concepts away from SEP-10-specific names.
+
+### Recommended boundaries and abstractions
+
+- `Sep10Authenticator`
+- `Sep45Authenticator`
+- `WebAuthSession`
+- `NonceRepository`
+- `ClientDomainResolver`
+- `RpcSimulationService`
+- `WebAuthDiscoveryTOMLAdapter`
+
+These are small, obvious boundaries. They are enough to avoid coupling, but not so many that the design becomes framework noise.
+
+### Minimum sensible implementation
+
+The minimum sensible Python implementation is:
+
+1. Add SEP-45 discovery fields to `stellar.toml`.
+2. Add `GET /sep45/auth` and `POST /sep45/auth`.
+3. Add a generic bearer-token authentication layer that accepts SEP-10 or SEP-45.
+4. Add nonce persistence and atomic consume.
+5. Update SEP-6, SEP-24, and SEP-38 to accept generic web-auth identity.
+6. Defer SEP-31 unless there is a concrete interoperability need.
+
+### What we should not overbuild initially
+
+- a separate auth service
+- generalized multi-contract policy engines
+- rich challenge persistence
+- broad abstraction for every possible Soroban auth pattern
+- custom client SDKs unless there is an immediate wallet integration need
+
+### What we should test aggressively
+
+- malformed and oversized `authorization_entries`
+- duplicate nonce submissions under concurrency
+- client-domain signer fetch over HTTPS
+- client-domain missing signature
+- home-domain normalization and matching
+- RPC auth-header propagation
+- downstream transaction and quote ownership checks with SEP-45 identities
+- mixed SEP-10 and SEP-45 bearer-token handling on the same API surface
+
+### Open unknowns before implementation begins
+
+- whether target wallets already implement the required client-side simulation and footprint validation
+- how much SEP-24 interactive flow behavior must change for contract-account users
+- whether product requirements demand shared-account-like behavior for contract wallets
+- whether SEP-31 support is actually needed in the first release
+- whether upstream Polaris evolution is expected to add SEP-45 in a way worth aligning with
+
+## 12. Open Questions / Risks / Ambiguities
+
+- SEP-45 remains `Draft`, so some details are still subject to change. ([SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md))
+- The current SEP-31 spec is less explicit about SEP-45 than SEP-6, SEP-24, and SEP-38.
+- Wallet-side compliance with the spec's simulation and footprint-verification guidance is uncertain.
+- Anchor Platform's current SEP-45 JWT issuer appears inconsistent with SEP-10 and the SEP text. That should be treated as an implementation detail to evaluate, not as a precedent to copy. ([Sep10Service](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java), [Sep45Service](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java))
+- Current Polaris is structurally SEP-10-centric enough that SEP-45 will likely require internal refactoring, not just additive endpoints.
+
+## 13. References
+
+- [SEP-45: Stellar Web Authentication for Contract Accounts](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md)
+- [SEP-1: Stellar Info File](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md)
+- [SEP-10: Stellar Web Authentication](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md)
+- [SEP-6: Anchor/Client Interoperability](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md)
+- [SEP-12: Customer Information Transfer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md)
+- [SEP-24: Hosted Deposit and Withdrawal](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md)
+- [SEP-31: Cross-Border Payments](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md)
+- [SEP-38: Anchor RFQ API](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md)
+- [Stellar Docs: Anchor Platform SEP-45 Guide](https://developers.stellar.org/platforms/anchor-platform/sep-guide/sep45)
+- [Anchor Platform `Sep45Service`](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java)
+- [Anchor Platform `Sep45Controller`](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep45Controller.java)
+- [Anchor Platform `PropertySep45Config`](https://github.com/stellar/anchor-platform/blob/develop/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep45Config.java)
+- [Anchor Platform `WebAuthJwtFilter`](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/filter/WebAuthJwtFilter.java)
+- [Anchor Platform `ClientDomainHelper`](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java)
+- [Anchor Platform `StellarRpc`](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/ledger/StellarRpc.java)
+- [Anchor Platform web-auth contract](https://github.com/stellar/anchor-platform/blob/develop/soroban/contracts/web-auth/src/lib.rs)
+- [Anchor Platform PR #1620: Add SEP-45 contracts](https://github.com/stellar/anchor-platform/pull/1620)
+- [Anchor Platform PR #1623: Implement SEP-45](https://github.com/stellar/anchor-platform/pull/1623)
+- [Anchor Platform PR #1639: Add SEP-45 config validation](https://github.com/stellar/anchor-platform/pull/1639)
+- [Anchor Platform PR #1657: Rename all `sep_10_account` fields to `web_auth_account`](https://github.com/stellar/anchor-platform/pull/1657)
+- [Anchor Platform PR #1659: Use SEP-45 JWT secret for signing SEP-45 JWTs](https://github.com/stellar/anchor-platform/pull/1659)
+- [Anchor Platform PR #1673: Add SEP-45 client domain verification tests](https://github.com/stellar/anchor-platform/pull/1673)
+- [Anchor Platform PR #1676: Implement nonce validation for SEP-45](https://github.com/stellar/anchor-platform/pull/1676)
+- [Anchor Platform PR #1697: Remove `SEP45_SIMULATING_SIGNING_SEED`](https://github.com/stellar/anchor-platform/pull/1697)
+- [Anchor Platform PR #1702: Update SEP-45 contract version](https://github.com/stellar/anchor-platform/pull/1702)
+- [Anchor Platform PR #1723: Contract Account Support](https://github.com/stellar/anchor-platform/pull/1723)
+- [Anchor Platform PR #1766: Enable sep45 for dev env](https://github.com/stellar/anchor-platform/pull/1766)
+- [Anchor Platform PR #1767: Fix sep45 helm chart](https://github.com/stellar/anchor-platform/pull/1767)
+- [Anchor Platform PR #1774: Fix sep45 homeDomain validation](https://github.com/stellar/anchor-platform/pull/1774)
+- [Anchor Platform commit `1e0a79e6`: Disable Sep45Tests if RPC URL is not set](https://github.com/stellar/anchor-platform/commit/1e0a79e655c64b990d17c07f5ebe289bd8812db0)
+- [Anchor Platform commit `eb383978`: Replace SorobanAuthEntryList with SorobanAuthEntries](https://github.com/stellar/anchor-platform/commit/eb3839787dcae5aa2b7c55cc54714cf2894801d5)
+- [Anchor Platform PR #1865: Fetch client domain signer over HTTPS](https://github.com/stellar/anchor-platform/pull/1865)
+- [Anchor Platform PR #1870: Fix SEP-45 request validation](https://github.com/stellar/anchor-platform/pull/1870)
+- [Anchor Platform PR #1900: Upgrade `java-stellar-sdk` to fix SEP-45 OOM](https://github.com/stellar/anchor-platform/pull/1900)
+- [Anchor Platform PR #1904: Fix RPC header auth not being sent in requests](https://github.com/stellar/anchor-platform/pull/1904)
+- [Anchor Platform PR #1906: Fix SEP-45 nonce TOCTOU race condition](https://github.com/stellar/anchor-platform/pull/1906)
+- [Anchor Platform release `3.2.0-beta.1`](https://github.com/stellar/anchor-platform/releases/tag/3.2.0-beta.1)
+- [Anchor Platform release `4.0.0`](https://github.com/stellar/anchor-platform/releases/tag/4.0.0)
+- [Anchor Platform release `4.1.8`](https://github.com/stellar/anchor-platform/releases/tag/4.1.8)
+- [Anchor Platform release `4.2.0`](https://github.com/stellar/anchor-platform/releases/tag/4.2.0)
+- [Stellar Protocol PR #1827: Handle archived SEP-45 contract instances](https://github.com/stellar/stellar-protocol/pull/1827)
+- [Django Polaris README](https://github.com/stellar/django-polaris/blob/master/README.rst)
+- [Django Polaris `polaris/sep10/token.py`](https://github.com/stellar/django-polaris/blob/master/polaris/sep10/token.py)
+- [Django Polaris `polaris/sep10/utils.py`](https://github.com/stellar/django-polaris/blob/master/polaris/sep10/utils.py)
+- [Django Polaris `polaris/models.py`](https://github.com/stellar/django-polaris/blob/master/polaris/models.py)
+- [Django Polaris `polaris/integrations/toml.py`](https://github.com/stellar/django-polaris/blob/master/polaris/integrations/toml.py)
+- [Django Polaris reference `stellar.toml`](https://github.com/stellar/django-polaris/blob/master/server/static/polaris/stellar.toml)
+- [Django Polaris releases](https://github.com/stellar/django-polaris/releases)

--- a/polaris/integrations/__init__.py
+++ b/polaris/integrations/__init__.py
@@ -9,6 +9,7 @@ from polaris.integrations.fees import calculate_fee, registered_fee_func
 from polaris.integrations.forms import TransactionForm, CreditCardForm
 from polaris.integrations.info import default_info_func, registered_info_func
 from polaris.integrations.quote import QuoteIntegration, registered_quote_integration
+from polaris.integrations.external_account import ExternalAccountIntegration, registered_external_account_integration
 from polaris.integrations.rails import RailsIntegration, registered_rails_integration
 from polaris.integrations.sep31 import (
     SEP31ReceiverIntegration,
@@ -39,6 +40,7 @@ def register_integrations(
     customer: CustomerIntegration = None,
     custody: CustodyIntegration = None,
     quote: QuoteIntegration = None,
+    external_account: ExternalAccountIntegration = None,
 ):
     """
     Registers the integration classes and functions with Polaris
@@ -122,6 +124,8 @@ def register_integrations(
         raise TypeError("custody must be a subclass of CustodyIntegration")
     elif quote and not issubclass(quote.__class__, QuoteIntegration):
         raise TypeError("quote must be a subclass of QuoteIntegration")
+    elif external_account and not issubclass(external_account.__class__, ExternalAccountIntegration):
+        raise TypeError("external_account must be a subclass of ExternalAccountIntegration")
 
     for obj, attr in [
         (deposit, "registered_deposit_integration"),
@@ -134,6 +138,7 @@ def register_integrations(
         (rails, "registered_rails_integration"),
         (custody, "registered_custody_integration"),
         (quote, "registered_quote_integration"),
+        (external_account, "registered_external_account_integration"),
     ]:
         if obj:
             setattr(this, attr, obj)

--- a/polaris/integrations/external_account.py
+++ b/polaris/integrations/external_account.py
@@ -1,0 +1,68 @@
+from typing import Union
+from rest_framework.request import Request
+from polaris.sep10.token import SEP10Token
+
+
+class ExternalAccountIntegration:
+    """
+    Base class for SEP-58 External Account API integrations.
+    Anchors subclass this and register via register_integrations(external_account=...).
+
+    Error conventions:
+        ValueError   -> 400 Bad Request
+        RuntimeError -> 503 Service Unavailable
+
+    KYC convention (same as SEP-6):
+        Return {"type": "non_interactive_customer_info_needed", "fields": [...]}
+        from create_account() instead of the normal tuple -> view returns 403.
+    """
+
+    def get_offerings(self, request: Request, *args, **kwargs) -> list:
+        """
+        Return list of offering dicts per SEP-58 /info spec.
+        No authentication required. Each dict should contain:
+        - kind: "crypto_address", "virtual_account", or "bank_account"
+        - For virtual_account/bank_account: country_code, currency, rail
+        - For crypto_address: chain_id, network
+        """
+        raise NotImplementedError()
+
+    def create_account(self, token: SEP10Token, request: Request, params: dict, *args, **kwargs) -> Union[tuple, dict]:
+        """
+        Create or return existing account for the authenticated user.
+
+        On success, return (account_dict, created: bool).
+        - account_dict: full Account Object per SEP-58 spec
+        - created: True if new account (201), False if reused existing (200)
+
+        On KYC needed, return a dict with "type" key (SEP-6 convention):
+        - {"type": "non_interactive_customer_info_needed", "fields": ["birth_date", ...]}
+
+        params contains validated fields:
+        - kind (always)
+        - country_code, currency (for virtual_account/bank_account)
+        - rail (optional, for virtual_account/bank_account)
+        - chain_id (for crypto_address)
+        - on_change_callback (optional)
+
+        Raise ValueError for bad request (400).
+        Raise RuntimeError for service unavailability (503).
+        """
+        raise NotImplementedError()
+
+    def get_account(self, token: SEP10Token, request: Request, account_id: str, *args, **kwargs) -> dict:
+        """
+        Return single account dict for the authenticated user.
+        Raise ValueError if not found (will return 404).
+        """
+        raise NotImplementedError()
+
+    def list_accounts(self, token: SEP10Token, request: Request, filters: dict, *args, **kwargs) -> list:
+        """
+        Return list of account dicts for the authenticated user.
+        filters may contain: kind, country_code, status (all optional).
+        """
+        raise NotImplementedError()
+
+
+registered_external_account_integration = ExternalAccountIntegration()

--- a/polaris/sep1/views.py
+++ b/polaris/sep1/views.py
@@ -84,6 +84,8 @@ def generate_toml(request: Request) -> Response:
         toml_dict["DIRECT_PAYMENT_SERVER"] = os.path.join(settings.HOST_URL, "sep31")
     if "sep-38" in settings.ACTIVE_SEPS:
         toml_dict["ANCHOR_QUOTE_SERVER"] = os.path.join(settings.HOST_URL, "sep38")
+    if "sep-58" in settings.ACTIVE_SEPS:
+        toml_dict["EXTERNAL_ACCOUNT_SERVER"] = os.path.join(settings.HOST_URL, "sep58")
 
     toml_dict.update(registered_toml_func(request))
     content = toml.dumps(toml_dict)

--- a/polaris/sep58/__init__.py
+++ b/polaris/sep58/__init__.py
@@ -1,0 +1,16 @@
+VALID_KINDS = ("crypto_address", "virtual_account", "bank_account")
+VALID_STATUSES = ("pending", "active", "deactivated", "error")
+
+# Required fields per kind for both offerings and account responses
+KIND_REQUIRED_FIELDS = {
+    "crypto_address": ("chain_id", "network"),
+    "virtual_account": ("country_code", "currency", "rail"),
+    "bank_account": ("country_code", "currency", "rail"),
+}
+
+
+def validate_kind_fields(obj: dict, kind: str, context: str = ""):
+    """Validate kind-specific required fields are present in a dict."""
+    for f in KIND_REQUIRED_FIELDS.get(kind, ()):
+        if f not in obj:
+            raise ValueError(f"kind={kind} missing '{f}'{context}")

--- a/polaris/sep58/accounts.py
+++ b/polaris/sep58/accounts.py
@@ -9,11 +9,10 @@ from rest_framework.response import Response
 from polaris.integrations import registered_external_account_integration as eai
 from polaris.sep10.token import SEP10Token
 from polaris.sep10.utils import validate_sep10_token
+from polaris.sep58 import VALID_KINDS, VALID_STATUSES, validate_kind_fields
 from polaris.utils import render_error_response
 
 logger = getLogger(__name__)
-
-VALID_KINDS = ("crypto_address", "virtual_account", "bank_account")
 
 
 @api_view(["GET", "POST"])
@@ -104,16 +103,9 @@ def _validate_account_response(account: dict, context: str = ""):
         raise ValueError(f"account missing required fields: {', '.join(missing)}{context}")
     if account["kind"] not in VALID_KINDS:
         raise ValueError(f"invalid account kind: {account['kind']}{context}")
-    if account["status"] not in ("pending", "active", "deactivated", "error"):
+    if account["status"] not in VALID_STATUSES:
         raise ValueError(f"invalid account status: {account['status']}{context}")
-    if account["kind"] in ("virtual_account", "bank_account"):
-        for f in ("country_code", "currency", "rail"):
-            if f not in account:
-                raise ValueError(f"account kind={account['kind']} missing '{f}'{context}")
-    elif account["kind"] == "crypto_address":
-        for f in ("chain_id", "network"):
-            if f not in account:
-                raise ValueError(f"account kind=crypto_address missing '{f}'{context}")
+    validate_kind_fields(account, account["kind"], context)
     if account["status"] == "active" and "instructions" not in account:
         raise ValueError(f"active account must include 'instructions'{context}")
 

--- a/polaris/sep58/accounts.py
+++ b/polaris/sep58/accounts.py
@@ -1,0 +1,151 @@
+from logging import getLogger
+
+from rest_framework.decorators import api_view, parser_classes, renderer_classes
+from rest_framework.parsers import JSONParser
+from rest_framework.renderers import JSONRenderer
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from polaris.integrations import registered_external_account_integration as eai
+from polaris.sep10.token import SEP10Token
+from polaris.sep10.utils import validate_sep10_token
+from polaris.utils import render_error_response
+
+logger = getLogger(__name__)
+
+VALID_KINDS = ("crypto_address", "virtual_account", "bank_account")
+
+
+@api_view(["GET", "POST"])
+@parser_classes([JSONParser])
+@renderer_classes([JSONRenderer])
+@validate_sep10_token()
+def accounts(token: SEP10Token, request: Request) -> Response:
+    if request.method == "POST":
+        return _create_account(token, request)
+    return _list_accounts(token, request)
+
+
+@api_view(["GET"])
+@renderer_classes([JSONRenderer])
+@validate_sep10_token()
+def get_account(token: SEP10Token, request: Request, account_id: str) -> Response:
+    try:
+        account = eai.get_account(token=token, request=request, account_id=account_id)
+    except ValueError as e:
+        return render_error_response(str(e), status_code=404)
+    except RuntimeError as e:
+        return render_error_response(str(e), status_code=503)
+    try:
+        _validate_account_response(account)
+    except ValueError as e:
+        logger.error(str(e))
+        return render_error_response("internal server error", status_code=500)
+    return Response({"account": account})
+
+
+def _create_account(token: SEP10Token, request: Request) -> Response:
+    try:
+        params = _validate_create_request(request)
+    except ValueError as e:
+        return render_error_response(str(e))
+
+    try:
+        result = eai.create_account(token=token, request=request, params=params)
+    except ValueError as e:
+        return render_error_response(str(e), status_code=400)
+    except RuntimeError as e:
+        return render_error_response(str(e), status_code=503)
+
+    # KYC needed -- SEP-6 dict-return convention
+    if isinstance(result, dict) and "type" in result:
+        return Response(result, status=403)
+
+    account, created = result
+    try:
+        _validate_account_response(account)
+    except ValueError as e:
+        logger.error(str(e))
+        return render_error_response("internal server error", status_code=500)
+    return Response({"account": account}, status=201 if created else 200)
+
+
+def _list_accounts(token: SEP10Token, request: Request) -> Response:
+    filters = {}
+    for key in ("kind", "country_code", "status"):
+        val = request.query_params.get(key)
+        if val:
+            filters[key] = val
+
+    try:
+        account_list = eai.list_accounts(token=token, request=request, filters=filters)
+    except ValueError as e:
+        return render_error_response(str(e), status_code=400)
+    except RuntimeError as e:
+        return render_error_response(str(e), status_code=503)
+
+    try:
+        for i, account in enumerate(account_list):
+            _validate_account_response(account, context=f" (list index {i})")
+    except ValueError as e:
+        logger.error(str(e))
+        return render_error_response("internal server error", status_code=500)
+
+    return Response({"accounts": account_list})
+
+
+def _validate_account_response(account: dict, context: str = ""):
+    """Validate account dict returned by integration matches SEP-58 spec."""
+    if not isinstance(account, dict):
+        raise ValueError(f"integration returned non-dict account object{context}")
+    required = ("id", "kind", "status", "stellar_asset", "stellar_account", "created_at", "updated_at")
+    missing = [f for f in required if f not in account]
+    if missing:
+        raise ValueError(f"account missing required fields: {', '.join(missing)}{context}")
+    if account["kind"] not in VALID_KINDS:
+        raise ValueError(f"invalid account kind: {account['kind']}{context}")
+    if account["status"] not in ("pending", "active", "deactivated", "error"):
+        raise ValueError(f"invalid account status: {account['status']}{context}")
+    if account["kind"] in ("virtual_account", "bank_account"):
+        for f in ("country_code", "currency", "rail"):
+            if f not in account:
+                raise ValueError(f"account kind={account['kind']} missing '{f}'{context}")
+    elif account["kind"] == "crypto_address":
+        for f in ("chain_id", "network"):
+            if f not in account:
+                raise ValueError(f"account kind=crypto_address missing '{f}'{context}")
+    if account["status"] == "active" and "instructions" not in account:
+        raise ValueError(f"active account must include 'instructions'{context}")
+
+
+def _validate_create_request(request: Request) -> dict:
+    kind = request.data.get("kind")
+    if not kind:
+        raise ValueError("'kind' is required")
+    if kind not in VALID_KINDS:
+        raise ValueError(f"'kind' must be one of: {', '.join(VALID_KINDS)}")
+
+    params = {"kind": kind}
+
+    if kind in ("virtual_account", "bank_account"):
+        for field in ("country_code", "currency"):
+            val = request.data.get(field)
+            if not val:
+                raise ValueError(f"'{field}' is required for {kind}")
+            params[field] = val
+        rail = request.data.get("rail")
+        if rail:
+            params["rail"] = rail
+    elif kind == "crypto_address":
+        chain_id = request.data.get("chain_id")
+        if not chain_id:
+            raise ValueError("'chain_id' is required for crypto_address")
+        params["chain_id"] = chain_id
+
+    callback = request.data.get("on_change_callback")
+    if callback:
+        if not callback.startswith("https://"):
+            raise ValueError("'on_change_callback' must be an HTTPS URL")
+        params["on_change_callback"] = callback
+
+    return params

--- a/polaris/sep58/info.py
+++ b/polaris/sep58/info.py
@@ -6,11 +6,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from polaris.integrations import registered_external_account_integration as eai
+from polaris.sep58 import VALID_KINDS, validate_kind_fields
 from polaris.utils import render_error_response
 
 logger = getLogger(__name__)
-
-VALID_KINDS = ("crypto_address", "virtual_account", "bank_account")
 
 
 @api_view(["GET"])
@@ -35,11 +34,4 @@ def _validate_offering(offering: dict, context: str = ""):
     kind = offering["kind"]
     if kind not in VALID_KINDS:
         raise ValueError(f"invalid offering kind: {kind}{context}")
-    if kind in ("virtual_account", "bank_account"):
-        for f in ("country_code", "currency", "rail"):
-            if f not in offering:
-                raise ValueError(f"offering kind={kind} missing '{f}'{context}")
-    elif kind == "crypto_address":
-        for f in ("chain_id", "network"):
-            if f not in offering:
-                raise ValueError(f"offering kind=crypto_address missing '{f}'{context}")
+    validate_kind_fields(offering, kind, context)

--- a/polaris/sep58/info.py
+++ b/polaris/sep58/info.py
@@ -1,0 +1,45 @@
+from logging import getLogger
+
+from rest_framework.decorators import api_view, renderer_classes
+from rest_framework.renderers import JSONRenderer
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from polaris.integrations import registered_external_account_integration as eai
+from polaris.utils import render_error_response
+
+logger = getLogger(__name__)
+
+VALID_KINDS = ("crypto_address", "virtual_account", "bank_account")
+
+
+@api_view(["GET"])
+@renderer_classes([JSONRenderer])
+def info(request: Request) -> Response:
+    offerings = eai.get_offerings(request=request)
+    try:
+        for i, offering in enumerate(offerings):
+            _validate_offering(offering, context=f" (offering index {i})")
+    except ValueError as e:
+        logger.error(str(e))
+        return render_error_response("internal server error", status_code=500)
+    return Response({"offerings": offerings})
+
+
+def _validate_offering(offering: dict, context: str = ""):
+    """Validate offering dict matches SEP-58 /info spec."""
+    if not isinstance(offering, dict):
+        raise ValueError(f"integration returned non-dict offering{context}")
+    if "kind" not in offering:
+        raise ValueError(f"offering missing 'kind'{context}")
+    kind = offering["kind"]
+    if kind not in VALID_KINDS:
+        raise ValueError(f"invalid offering kind: {kind}{context}")
+    if kind in ("virtual_account", "bank_account"):
+        for f in ("country_code", "currency", "rail"):
+            if f not in offering:
+                raise ValueError(f"offering kind={kind} missing '{f}'{context}")
+    elif kind == "crypto_address":
+        for f in ("chain_id", "network"):
+            if f not in offering:
+                raise ValueError(f"offering kind=crypto_address missing '{f}'{context}")

--- a/polaris/sep58/urls.py
+++ b/polaris/sep58/urls.py
@@ -1,0 +1,8 @@
+from django.urls import re_path
+from polaris.sep58 import info, accounts
+
+urlpatterns = [
+    re_path(r"^info/?$", info.info),
+    re_path(r"^accounts/?$", accounts.accounts),
+    re_path(r"^accounts/(?P<account_id>[^/]+)/?$", accounts.get_account),
+]

--- a/polaris/settings.py
+++ b/polaris/settings.py
@@ -50,6 +50,7 @@ accepted_seps = [
     "sep-24",
     "sep-31",
     "sep-38",
+    "sep-58",
 ]
 ACTIVE_SEPS = env_or_settings("ACTIVE_SEPS", list=True)
 for i, sep in enumerate(ACTIVE_SEPS):

--- a/polaris/tests/sep1/test_toml.py
+++ b/polaris/tests/sep1/test_toml.py
@@ -22,7 +22,7 @@ def test_toml_generated(mock_toml_func, client):
     )
     with patch(
         f"{TEST_MODULE}.settings.ACTIVE_SEPS",
-        ["sep-1", "sep-6", "sep-10", "sep-12", "sep-24", "sep-31", "sep-38"],
+        ["sep-1", "sep-6", "sep-10", "sep-12", "sep-24", "sep-31", "sep-38", "sep-58"],
     ):
         response = client.get(TOML_PATH)
     assert response.status_code == 200
@@ -40,6 +40,8 @@ def test_toml_generated(mock_toml_func, client):
     assert "KYC_SERVER" in toml_data
     assert "DIRECT_PAYMENT_SERVER" in toml_data
     assert "ANCHOR_QUOTE_SERVER" in toml_data
+    assert "EXTERNAL_ACCOUNT_SERVER" in toml_data
+    assert toml_data["EXTERNAL_ACCOUNT_SERVER"].endswith("/sep58")
     assert toml_data["TRANSFER_SERVER"] != toml_data["TRANSFER_SERVER_SEP0024"]
     assert toml_data["ACCOUNTS"] == [usd.distribution_account]
     assert toml_data["NETWORK_PASSPHRASE"] == settings.STELLAR_NETWORK_PASSPHRASE

--- a/polaris/tests/sep58/test_accounts.py
+++ b/polaris/tests/sep58/test_accounts.py
@@ -1,14 +1,11 @@
 import json
+from copy import deepcopy
 from unittest.mock import patch, Mock
-
-import pytest
 
 from polaris.tests.helpers import mock_check_auth_success
 
 ACCOUNTS_ENDPOINT = "/sep58/accounts"
 code_path = "polaris.sep58.accounts"
-
-# --- Shared fixtures ---
 
 VALID_CRYPTO_ADDRESS = {
     "id": "acc_crypto_1", "kind": "crypto_address", "status": "active",
@@ -39,11 +36,21 @@ def _post(client, data):
     return client.post(ACCOUNTS_ENDPOINT, json.dumps(data), content_type="application/json")
 
 
+def _make_invalid_account(**overrides):
+    """Deep-copy a valid crypto_address and apply overrides / removals."""
+    base = deepcopy(VALID_CRYPTO_ADDRESS)
+    for key, val in overrides.items():
+        if val is None:
+            base.pop(key, None)
+        else:
+            base[key] = val
+    return base
+
+
 # ============================================================
 # POST /accounts — request validation (AC1)
 # ============================================================
 
-# --- 6.4 ---
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_missing_kind_400(client):
     response = _post(client, {})
@@ -51,7 +58,6 @@ def test_create_account_missing_kind_400(client):
     assert "kind" in response.json()["error"].lower()
 
 
-# --- 6.5 ---
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_invalid_kind_400(client):
     response = _post(client, {"kind": "invalid"})
@@ -59,7 +65,6 @@ def test_create_account_invalid_kind_400(client):
     assert "must be one of" in response.json()["error"]
 
 
-# --- 6.6 ---
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_virtual_account_missing_country_code_400(client):
     response = _post(client, {"kind": "virtual_account", "currency": "USD"})
@@ -67,7 +72,6 @@ def test_create_account_virtual_account_missing_country_code_400(client):
     assert "country_code" in response.json()["error"]
 
 
-# --- 6.7 ---
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_virtual_account_missing_currency_400(client):
     response = _post(client, {"kind": "virtual_account", "country_code": "US"})
@@ -75,7 +79,6 @@ def test_create_account_virtual_account_missing_currency_400(client):
     assert "currency" in response.json()["error"]
 
 
-# --- 6.8 ---
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_bank_account_missing_country_code_400(client):
     response = _post(client, {"kind": "bank_account", "currency": "MXN"})
@@ -83,7 +86,6 @@ def test_create_account_bank_account_missing_country_code_400(client):
     assert "country_code" in response.json()["error"]
 
 
-# --- 6.9 ---
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_bank_account_missing_currency_400(client):
     response = _post(client, {"kind": "bank_account", "country_code": "MX"})
@@ -91,7 +93,6 @@ def test_create_account_bank_account_missing_currency_400(client):
     assert "currency" in response.json()["error"]
 
 
-# --- 6.10 ---
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_crypto_address_missing_chain_id_400(client):
     response = _post(client, {"kind": "crypto_address"})
@@ -99,7 +100,6 @@ def test_create_account_crypto_address_missing_chain_id_400(client):
     assert "chain_id" in response.json()["error"]
 
 
-# --- 6.11 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_non_https_callback_400(mock_eai, client):
@@ -111,11 +111,10 @@ def test_create_account_non_https_callback_400(mock_eai, client):
     assert "HTTPS" in response.json()["error"]
 
 
-# --- 6.12 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_https_callback_passthrough(mock_eai, client):
-    mock_eai.create_account = Mock(return_value=(VALID_CRYPTO_ADDRESS, True))
+    mock_eai.create_account = Mock(return_value=(deepcopy(VALID_CRYPTO_ADDRESS), True))
     response = _post(client, {
         "kind": "crypto_address", "chain_id": "eip155:1",
         "on_change_callback": "https://example.com/hook",
@@ -129,7 +128,6 @@ def test_create_account_https_callback_passthrough(mock_eai, client):
 # POST /accounts — integration error conventions (AC2)
 # ============================================================
 
-# --- 6.13 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_value_error_400(mock_eai, client):
@@ -138,7 +136,6 @@ def test_create_account_value_error_400(mock_eai, client):
     assert response.status_code == 400
 
 
-# --- 6.14 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_runtime_error_503(mock_eai, client):
@@ -147,7 +144,6 @@ def test_create_account_runtime_error_503(mock_eai, client):
     assert response.status_code == 503
 
 
-# --- 6.15 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_kyc_403(mock_eai, client):
@@ -164,11 +160,10 @@ def test_create_account_kyc_403(mock_eai, client):
 # POST /accounts — per-kind valid response shapes (AC3)
 # ============================================================
 
-# --- 6.16 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_crypto_address_success_201(mock_eai, client):
-    mock_eai.create_account = Mock(return_value=(VALID_CRYPTO_ADDRESS, True))
+    mock_eai.create_account = Mock(return_value=(deepcopy(VALID_CRYPTO_ADDRESS), True))
     response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
     assert response.status_code == 201
     account = response.json()["account"]
@@ -177,11 +172,10 @@ def test_create_crypto_address_success_201(mock_eai, client):
     assert "network" in account
 
 
-# --- 6.17 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_virtual_account_success_201(mock_eai, client):
-    mock_eai.create_account = Mock(return_value=(VALID_VIRTUAL_ACCOUNT, True))
+    mock_eai.create_account = Mock(return_value=(deepcopy(VALID_VIRTUAL_ACCOUNT), True))
     response = _post(client, {"kind": "virtual_account", "country_code": "US", "currency": "USD"})
     assert response.status_code == 201
     account = response.json()["account"]
@@ -191,11 +185,10 @@ def test_create_virtual_account_success_201(mock_eai, client):
     assert "rail" in account
 
 
-# --- 6.18 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_bank_account_success_201(mock_eai, client):
-    mock_eai.create_account = Mock(return_value=(VALID_BANK_ACCOUNT, True))
+    mock_eai.create_account = Mock(return_value=(deepcopy(VALID_BANK_ACCOUNT), True))
     response = _post(client, {"kind": "bank_account", "country_code": "MX", "currency": "MXN"})
     assert response.status_code == 201
     account = response.json()["account"]
@@ -205,11 +198,10 @@ def test_create_bank_account_success_201(mock_eai, client):
     assert "rail" in account
 
 
-# --- 6.19 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_existing_200(mock_eai, client):
-    mock_eai.create_account = Mock(return_value=(VALID_CRYPTO_ADDRESS, False))
+    mock_eai.create_account = Mock(return_value=(deepcopy(VALID_CRYPTO_ADDRESS), False))
     response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
     assert response.status_code == 200
 
@@ -218,18 +210,6 @@ def test_create_account_existing_200(mock_eai, client):
 # POST /accounts — per-kind invalid response shapes (AC3)
 # ============================================================
 
-def _make_invalid_account(**overrides):
-    """Start from a valid crypto_address and apply overrides / removals."""
-    base = dict(VALID_CRYPTO_ADDRESS)
-    for key, val in overrides.items():
-        if val is None:
-            base.pop(key, None)
-        else:
-            base[key] = val
-    return base
-
-
-# --- 6.20 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_crypto_address_missing_chain_id_500(mock_eai, client):
@@ -239,7 +219,6 @@ def test_create_crypto_address_missing_chain_id_500(mock_eai, client):
     assert response.status_code == 500
 
 
-# --- 6.21 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_crypto_address_missing_network_500(mock_eai, client):
@@ -249,51 +228,46 @@ def test_create_crypto_address_missing_network_500(mock_eai, client):
     assert response.status_code == 500
 
 
-# --- 6.22 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_virtual_account_missing_country_code_500(mock_eai, client):
-    bad = dict(VALID_VIRTUAL_ACCOUNT)
+    bad = deepcopy(VALID_VIRTUAL_ACCOUNT)
     del bad["country_code"]
     mock_eai.create_account = Mock(return_value=(bad, True))
     response = _post(client, {"kind": "virtual_account", "country_code": "US", "currency": "USD"})
     assert response.status_code == 500
 
 
-# --- 6.23 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_virtual_account_missing_currency_500(mock_eai, client):
-    bad = dict(VALID_VIRTUAL_ACCOUNT)
+    bad = deepcopy(VALID_VIRTUAL_ACCOUNT)
     del bad["currency"]
     mock_eai.create_account = Mock(return_value=(bad, True))
     response = _post(client, {"kind": "virtual_account", "country_code": "US", "currency": "USD"})
     assert response.status_code == 500
 
 
-# --- 6.24 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_virtual_account_missing_rail_500(mock_eai, client):
-    bad = dict(VALID_VIRTUAL_ACCOUNT)
+    bad = deepcopy(VALID_VIRTUAL_ACCOUNT)
     del bad["rail"]
     mock_eai.create_account = Mock(return_value=(bad, True))
     response = _post(client, {"kind": "virtual_account", "country_code": "US", "currency": "USD"})
     assert response.status_code == 500
 
 
-# --- 6.25 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_bank_account_missing_rail_500(mock_eai, client):
-    bad = dict(VALID_BANK_ACCOUNT)
+    bad = deepcopy(VALID_BANK_ACCOUNT)
     del bad["rail"]
     mock_eai.create_account = Mock(return_value=(bad, True))
     response = _post(client, {"kind": "bank_account", "country_code": "MX", "currency": "MXN"})
     assert response.status_code == 500
 
 
-# --- 6.26 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_active_account_missing_instructions_500(mock_eai, client):
@@ -303,7 +277,6 @@ def test_create_active_account_missing_instructions_500(mock_eai, client):
     assert response.status_code == 500
 
 
-# --- 6.27 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_missing_common_fields_500(mock_eai, client):
@@ -313,7 +286,6 @@ def test_create_account_missing_common_fields_500(mock_eai, client):
     assert response.status_code == 500
 
 
-# --- 6.28 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_create_account_invalid_status_500(mock_eai, client):
@@ -327,17 +299,15 @@ def test_create_account_invalid_status_500(mock_eai, client):
 # GET /accounts/:id (AC1 + AC2)
 # ============================================================
 
-# --- 6.29 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_get_account_success(mock_eai, client):
-    mock_eai.get_account = Mock(return_value=VALID_CRYPTO_ADDRESS)
+    mock_eai.get_account = Mock(return_value=deepcopy(VALID_CRYPTO_ADDRESS))
     response = client.get(f"{ACCOUNTS_ENDPOINT}/acc_crypto_1")
     assert response.status_code == 200
     assert response.json()["account"]["id"] == "acc_crypto_1"
 
 
-# --- 6.30 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_get_account_not_found_404(mock_eai, client):
@@ -346,7 +316,6 @@ def test_get_account_not_found_404(mock_eai, client):
     assert response.status_code == 404
 
 
-# --- 6.31 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_get_account_runtime_error_503(mock_eai, client):
@@ -355,7 +324,6 @@ def test_get_account_runtime_error_503(mock_eai, client):
     assert response.status_code == 503
 
 
-# --- 6.32 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_get_account_validation_failure_500(mock_eai, client):
@@ -368,29 +336,26 @@ def test_get_account_validation_failure_500(mock_eai, client):
 # GET /accounts — success + errors (AC1 + AC2)
 # ============================================================
 
-# --- 6.33 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_list_accounts_success(mock_eai, client):
-    mock_eai.list_accounts = Mock(return_value=[VALID_CRYPTO_ADDRESS, VALID_VIRTUAL_ACCOUNT])
+    mock_eai.list_accounts = Mock(return_value=[deepcopy(VALID_CRYPTO_ADDRESS), deepcopy(VALID_VIRTUAL_ACCOUNT)])
     response = client.get(ACCOUNTS_ENDPOINT)
     assert response.status_code == 200
     body = response.json()
     assert len(body["accounts"]) == 2
 
 
-# --- 6.34 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_list_accounts_with_filters(mock_eai, client):
-    mock_eai.list_accounts = Mock(return_value=[VALID_CRYPTO_ADDRESS])
+    mock_eai.list_accounts = Mock(return_value=[deepcopy(VALID_CRYPTO_ADDRESS)])
     response = client.get(ACCOUNTS_ENDPOINT, {"kind": "crypto_address", "status": "active"})
     assert response.status_code == 200
     call_kwargs = mock_eai.list_accounts.call_args[1]
     assert call_kwargs["filters"] == {"kind": "crypto_address", "status": "active"}
 
 
-# --- 6.35 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_list_accounts_value_error_400(mock_eai, client):
@@ -399,7 +364,6 @@ def test_list_accounts_value_error_400(mock_eai, client):
     assert response.status_code == 400
 
 
-# --- 6.36 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_list_accounts_runtime_error_503(mock_eai, client):
@@ -412,7 +376,6 @@ def test_list_accounts_runtime_error_503(mock_eai, client):
 # GET /accounts — list-level response validation (AC2 + AC3)
 # ============================================================
 
-# --- 6.37 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_list_accounts_malformed_item_500(mock_eai, client):
@@ -421,11 +384,10 @@ def test_list_accounts_malformed_item_500(mock_eai, client):
     assert response.status_code == 500
 
 
-# --- 6.38 ---
 @patch(f"{code_path}.eai")
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
 def test_list_accounts_mixed_kinds_valid(mock_eai, client):
-    mock_eai.list_accounts = Mock(return_value=[VALID_CRYPTO_ADDRESS, VALID_VIRTUAL_ACCOUNT, VALID_BANK_ACCOUNT])
+    mock_eai.list_accounts = Mock(return_value=[deepcopy(VALID_CRYPTO_ADDRESS), deepcopy(VALID_VIRTUAL_ACCOUNT), deepcopy(VALID_BANK_ACCOUNT)])
     response = client.get(ACCOUNTS_ENDPOINT)
     assert response.status_code == 200
     assert len(response.json()["accounts"]) == 3
@@ -435,17 +397,13 @@ def test_list_accounts_mixed_kinds_valid(mock_eai, client):
 # Auth (AC1)
 # ============================================================
 
-# --- 6.46 ---
 def test_accounts_requires_auth(client):
     """POST, GET /accounts, and GET /accounts/:id without token should 403."""
-    # POST /accounts
     response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
     assert response.status_code == 403
 
-    # GET /accounts
     response = client.get(ACCOUNTS_ENDPOINT)
     assert response.status_code == 403
 
-    # GET /accounts/:id
     response = client.get(f"{ACCOUNTS_ENDPOINT}/some_id")
     assert response.status_code == 403

--- a/polaris/tests/sep58/test_accounts.py
+++ b/polaris/tests/sep58/test_accounts.py
@@ -1,0 +1,451 @@
+import json
+from unittest.mock import patch, Mock
+
+import pytest
+
+from polaris.tests.helpers import mock_check_auth_success
+
+ACCOUNTS_ENDPOINT = "/sep58/accounts"
+code_path = "polaris.sep58.accounts"
+
+# --- Shared fixtures ---
+
+VALID_CRYPTO_ADDRESS = {
+    "id": "acc_crypto_1", "kind": "crypto_address", "status": "active",
+    "stellar_asset": "USDC:GABCD", "stellar_account": "GABCD",
+    "chain_id": "eip155:1", "network": "Ethereum Mainnet",
+    "instructions": {"organization.crypto_address": {"value": "0xABC", "description": "Deposit address"}},
+    "created_at": "2026-03-19T10:00:00Z", "updated_at": "2026-03-19T10:00:00Z",
+}
+
+VALID_VIRTUAL_ACCOUNT = {
+    "id": "acc_va_1", "kind": "virtual_account", "status": "active",
+    "stellar_asset": "USDC:GABCD", "stellar_account": "GABCD",
+    "country_code": "US", "currency": "USD", "rail": "ACH",
+    "instructions": {"organization.bank_account_number": {"value": "123", "description": "Account number"}},
+    "created_at": "2026-03-19T10:00:00Z", "updated_at": "2026-03-19T10:00:00Z",
+}
+
+VALID_BANK_ACCOUNT = {
+    "id": "acc_bank_1", "kind": "bank_account", "status": "active",
+    "stellar_asset": "USDC:GABCD", "stellar_account": "GABCD",
+    "country_code": "MX", "currency": "MXN", "rail": "SPEI",
+    "instructions": {"organization.clabe_number": {"value": "646180111803859359", "description": "CLABE"}},
+    "created_at": "2026-03-19T10:00:00Z", "updated_at": "2026-03-19T10:00:00Z",
+}
+
+
+def _post(client, data):
+    return client.post(ACCOUNTS_ENDPOINT, json.dumps(data), content_type="application/json")
+
+
+# ============================================================
+# POST /accounts — request validation (AC1)
+# ============================================================
+
+# --- 6.4 ---
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_missing_kind_400(client):
+    response = _post(client, {})
+    assert response.status_code == 400
+    assert "kind" in response.json()["error"].lower()
+
+
+# --- 6.5 ---
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_invalid_kind_400(client):
+    response = _post(client, {"kind": "invalid"})
+    assert response.status_code == 400
+    assert "must be one of" in response.json()["error"]
+
+
+# --- 6.6 ---
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_virtual_account_missing_country_code_400(client):
+    response = _post(client, {"kind": "virtual_account", "currency": "USD"})
+    assert response.status_code == 400
+    assert "country_code" in response.json()["error"]
+
+
+# --- 6.7 ---
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_virtual_account_missing_currency_400(client):
+    response = _post(client, {"kind": "virtual_account", "country_code": "US"})
+    assert response.status_code == 400
+    assert "currency" in response.json()["error"]
+
+
+# --- 6.8 ---
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_bank_account_missing_country_code_400(client):
+    response = _post(client, {"kind": "bank_account", "currency": "MXN"})
+    assert response.status_code == 400
+    assert "country_code" in response.json()["error"]
+
+
+# --- 6.9 ---
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_bank_account_missing_currency_400(client):
+    response = _post(client, {"kind": "bank_account", "country_code": "MX"})
+    assert response.status_code == 400
+    assert "currency" in response.json()["error"]
+
+
+# --- 6.10 ---
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_crypto_address_missing_chain_id_400(client):
+    response = _post(client, {"kind": "crypto_address"})
+    assert response.status_code == 400
+    assert "chain_id" in response.json()["error"]
+
+
+# --- 6.11 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_non_https_callback_400(mock_eai, client):
+    response = _post(client, {
+        "kind": "crypto_address", "chain_id": "eip155:1",
+        "on_change_callback": "http://example.com/hook",
+    })
+    assert response.status_code == 400
+    assert "HTTPS" in response.json()["error"]
+
+
+# --- 6.12 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_https_callback_passthrough(mock_eai, client):
+    mock_eai.create_account = Mock(return_value=(VALID_CRYPTO_ADDRESS, True))
+    response = _post(client, {
+        "kind": "crypto_address", "chain_id": "eip155:1",
+        "on_change_callback": "https://example.com/hook",
+    })
+    assert response.status_code == 201
+    call_kwargs = mock_eai.create_account.call_args[1]
+    assert call_kwargs["params"]["on_change_callback"] == "https://example.com/hook"
+
+
+# ============================================================
+# POST /accounts — integration error conventions (AC2)
+# ============================================================
+
+# --- 6.13 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_value_error_400(mock_eai, client):
+    mock_eai.create_account = Mock(side_effect=ValueError("bad request"))
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 400
+
+
+# --- 6.14 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_runtime_error_503(mock_eai, client):
+    mock_eai.create_account = Mock(side_effect=RuntimeError("service down"))
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 503
+
+
+# --- 6.15 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_kyc_403(mock_eai, client):
+    kyc_response = {"type": "non_interactive_customer_info_needed", "fields": ["birth_date"]}
+    mock_eai.create_account = Mock(return_value=kyc_response)
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 403
+    body = response.json()
+    assert body["type"] == "non_interactive_customer_info_needed"
+    assert "fields" in body
+
+
+# ============================================================
+# POST /accounts — per-kind valid response shapes (AC3)
+# ============================================================
+
+# --- 6.16 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_crypto_address_success_201(mock_eai, client):
+    mock_eai.create_account = Mock(return_value=(VALID_CRYPTO_ADDRESS, True))
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 201
+    account = response.json()["account"]
+    assert account["kind"] == "crypto_address"
+    assert "chain_id" in account
+    assert "network" in account
+
+
+# --- 6.17 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_virtual_account_success_201(mock_eai, client):
+    mock_eai.create_account = Mock(return_value=(VALID_VIRTUAL_ACCOUNT, True))
+    response = _post(client, {"kind": "virtual_account", "country_code": "US", "currency": "USD"})
+    assert response.status_code == 201
+    account = response.json()["account"]
+    assert account["kind"] == "virtual_account"
+    assert "country_code" in account
+    assert "currency" in account
+    assert "rail" in account
+
+
+# --- 6.18 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_bank_account_success_201(mock_eai, client):
+    mock_eai.create_account = Mock(return_value=(VALID_BANK_ACCOUNT, True))
+    response = _post(client, {"kind": "bank_account", "country_code": "MX", "currency": "MXN"})
+    assert response.status_code == 201
+    account = response.json()["account"]
+    assert account["kind"] == "bank_account"
+    assert "country_code" in account
+    assert "currency" in account
+    assert "rail" in account
+
+
+# --- 6.19 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_existing_200(mock_eai, client):
+    mock_eai.create_account = Mock(return_value=(VALID_CRYPTO_ADDRESS, False))
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 200
+
+
+# ============================================================
+# POST /accounts — per-kind invalid response shapes (AC3)
+# ============================================================
+
+def _make_invalid_account(**overrides):
+    """Start from a valid crypto_address and apply overrides / removals."""
+    base = dict(VALID_CRYPTO_ADDRESS)
+    for key, val in overrides.items():
+        if val is None:
+            base.pop(key, None)
+        else:
+            base[key] = val
+    return base
+
+
+# --- 6.20 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_crypto_address_missing_chain_id_500(mock_eai, client):
+    bad = _make_invalid_account(chain_id=None)
+    mock_eai.create_account = Mock(return_value=(bad, True))
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 500
+
+
+# --- 6.21 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_crypto_address_missing_network_500(mock_eai, client):
+    bad = _make_invalid_account(network=None)
+    mock_eai.create_account = Mock(return_value=(bad, True))
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 500
+
+
+# --- 6.22 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_virtual_account_missing_country_code_500(mock_eai, client):
+    bad = dict(VALID_VIRTUAL_ACCOUNT)
+    del bad["country_code"]
+    mock_eai.create_account = Mock(return_value=(bad, True))
+    response = _post(client, {"kind": "virtual_account", "country_code": "US", "currency": "USD"})
+    assert response.status_code == 500
+
+
+# --- 6.23 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_virtual_account_missing_currency_500(mock_eai, client):
+    bad = dict(VALID_VIRTUAL_ACCOUNT)
+    del bad["currency"]
+    mock_eai.create_account = Mock(return_value=(bad, True))
+    response = _post(client, {"kind": "virtual_account", "country_code": "US", "currency": "USD"})
+    assert response.status_code == 500
+
+
+# --- 6.24 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_virtual_account_missing_rail_500(mock_eai, client):
+    bad = dict(VALID_VIRTUAL_ACCOUNT)
+    del bad["rail"]
+    mock_eai.create_account = Mock(return_value=(bad, True))
+    response = _post(client, {"kind": "virtual_account", "country_code": "US", "currency": "USD"})
+    assert response.status_code == 500
+
+
+# --- 6.25 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_bank_account_missing_rail_500(mock_eai, client):
+    bad = dict(VALID_BANK_ACCOUNT)
+    del bad["rail"]
+    mock_eai.create_account = Mock(return_value=(bad, True))
+    response = _post(client, {"kind": "bank_account", "country_code": "MX", "currency": "MXN"})
+    assert response.status_code == 500
+
+
+# --- 6.26 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_active_account_missing_instructions_500(mock_eai, client):
+    bad = _make_invalid_account(instructions=None)
+    mock_eai.create_account = Mock(return_value=(bad, True))
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 500
+
+
+# --- 6.27 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_missing_common_fields_500(mock_eai, client):
+    bad = {"kind": "crypto_address"}
+    mock_eai.create_account = Mock(return_value=(bad, True))
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 500
+
+
+# --- 6.28 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_create_account_invalid_status_500(mock_eai, client):
+    bad = _make_invalid_account(status="bogus")
+    mock_eai.create_account = Mock(return_value=(bad, True))
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 500
+
+
+# ============================================================
+# GET /accounts/:id (AC1 + AC2)
+# ============================================================
+
+# --- 6.29 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_get_account_success(mock_eai, client):
+    mock_eai.get_account = Mock(return_value=VALID_CRYPTO_ADDRESS)
+    response = client.get(f"{ACCOUNTS_ENDPOINT}/acc_crypto_1")
+    assert response.status_code == 200
+    assert response.json()["account"]["id"] == "acc_crypto_1"
+
+
+# --- 6.30 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_get_account_not_found_404(mock_eai, client):
+    mock_eai.get_account = Mock(side_effect=ValueError("not found"))
+    response = client.get(f"{ACCOUNTS_ENDPOINT}/nonexistent")
+    assert response.status_code == 404
+
+
+# --- 6.31 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_get_account_runtime_error_503(mock_eai, client):
+    mock_eai.get_account = Mock(side_effect=RuntimeError("service down"))
+    response = client.get(f"{ACCOUNTS_ENDPOINT}/acc_crypto_1")
+    assert response.status_code == 503
+
+
+# --- 6.32 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_get_account_validation_failure_500(mock_eai, client):
+    mock_eai.get_account = Mock(return_value={"kind": "crypto_address"})
+    response = client.get(f"{ACCOUNTS_ENDPOINT}/acc_crypto_1")
+    assert response.status_code == 500
+
+
+# ============================================================
+# GET /accounts — success + errors (AC1 + AC2)
+# ============================================================
+
+# --- 6.33 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_list_accounts_success(mock_eai, client):
+    mock_eai.list_accounts = Mock(return_value=[VALID_CRYPTO_ADDRESS, VALID_VIRTUAL_ACCOUNT])
+    response = client.get(ACCOUNTS_ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["accounts"]) == 2
+
+
+# --- 6.34 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_list_accounts_with_filters(mock_eai, client):
+    mock_eai.list_accounts = Mock(return_value=[VALID_CRYPTO_ADDRESS])
+    response = client.get(ACCOUNTS_ENDPOINT, {"kind": "crypto_address", "status": "active"})
+    assert response.status_code == 200
+    call_kwargs = mock_eai.list_accounts.call_args[1]
+    assert call_kwargs["filters"] == {"kind": "crypto_address", "status": "active"}
+
+
+# --- 6.35 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_list_accounts_value_error_400(mock_eai, client):
+    mock_eai.list_accounts = Mock(side_effect=ValueError("bad filter"))
+    response = client.get(ACCOUNTS_ENDPOINT)
+    assert response.status_code == 400
+
+
+# --- 6.36 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_list_accounts_runtime_error_503(mock_eai, client):
+    mock_eai.list_accounts = Mock(side_effect=RuntimeError("service down"))
+    response = client.get(ACCOUNTS_ENDPOINT)
+    assert response.status_code == 503
+
+
+# ============================================================
+# GET /accounts — list-level response validation (AC2 + AC3)
+# ============================================================
+
+# --- 6.37 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_list_accounts_malformed_item_500(mock_eai, client):
+    mock_eai.list_accounts = Mock(return_value=[{"kind": "crypto_address"}])
+    response = client.get(ACCOUNTS_ENDPOINT)
+    assert response.status_code == 500
+
+
+# --- 6.38 ---
+@patch(f"{code_path}.eai")
+@patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
+def test_list_accounts_mixed_kinds_valid(mock_eai, client):
+    mock_eai.list_accounts = Mock(return_value=[VALID_CRYPTO_ADDRESS, VALID_VIRTUAL_ACCOUNT, VALID_BANK_ACCOUNT])
+    response = client.get(ACCOUNTS_ENDPOINT)
+    assert response.status_code == 200
+    assert len(response.json()["accounts"]) == 3
+
+
+# ============================================================
+# Auth (AC1)
+# ============================================================
+
+# --- 6.46 ---
+def test_accounts_requires_auth(client):
+    """POST, GET /accounts, and GET /accounts/:id without token should 403."""
+    # POST /accounts
+    response = _post(client, {"kind": "crypto_address", "chain_id": "eip155:1"})
+    assert response.status_code == 403
+
+    # GET /accounts
+    response = client.get(ACCOUNTS_ENDPOINT)
+    assert response.status_code == 403
+
+    # GET /accounts/:id
+    response = client.get(f"{ACCOUNTS_ENDPOINT}/some_id")
+    assert response.status_code == 403

--- a/polaris/tests/sep58/test_info.py
+++ b/polaris/tests/sep58/test_info.py
@@ -1,14 +1,11 @@
 from unittest.mock import patch, Mock
 
-import pytest
-
 from polaris.tests.helpers import mock_check_auth_success
 
 INFO_ENDPOINT = "/sep58/info"
 code_path = "polaris.sep58.info"
 
 
-# --- 6.2 test_info_returns_offerings ---
 @patch(f"{code_path}.eai")
 def test_info_returns_offerings(mock_eai, client):
     mock_eai.get_offerings = Mock(return_value=[
@@ -23,7 +20,6 @@ def test_info_returns_offerings(mock_eai, client):
     mock_eai.get_offerings.assert_called_once()
 
 
-# --- 6.3 test_info_no_auth_required ---
 @patch(f"{code_path}.eai")
 def test_info_no_auth_required(mock_eai, client):
     """No token provided — should still return 200, not 403."""
@@ -32,7 +28,6 @@ def test_info_no_auth_required(mock_eai, client):
     assert response.status_code == 200
 
 
-# --- 6.39 test_info_crypto_address_offering_valid ---
 @patch(f"{code_path}.eai")
 def test_info_crypto_address_offering_valid(mock_eai, client):
     mock_eai.get_offerings = Mock(return_value=[
@@ -42,7 +37,6 @@ def test_info_crypto_address_offering_valid(mock_eai, client):
     assert response.status_code == 200
 
 
-# --- 6.40 test_info_virtual_account_offering_valid ---
 @patch(f"{code_path}.eai")
 def test_info_virtual_account_offering_valid(mock_eai, client):
     mock_eai.get_offerings = Mock(return_value=[
@@ -52,7 +46,6 @@ def test_info_virtual_account_offering_valid(mock_eai, client):
     assert response.status_code == 200
 
 
-# --- 6.41 test_info_bank_account_offering_valid ---
 @patch(f"{code_path}.eai")
 def test_info_bank_account_offering_valid(mock_eai, client):
     mock_eai.get_offerings = Mock(return_value=[
@@ -62,7 +55,6 @@ def test_info_bank_account_offering_valid(mock_eai, client):
     assert response.status_code == 200
 
 
-# --- 6.42 test_info_offering_missing_kind_500 ---
 @patch(f"{code_path}.eai")
 def test_info_offering_missing_kind_500(mock_eai, client):
     mock_eai.get_offerings = Mock(return_value=[{"country_code": "US"}])
@@ -70,7 +62,6 @@ def test_info_offering_missing_kind_500(mock_eai, client):
     assert response.status_code == 500
 
 
-# --- 6.43 test_info_crypto_offering_missing_chain_id_500 ---
 @patch(f"{code_path}.eai")
 def test_info_crypto_offering_missing_chain_id_500(mock_eai, client):
     mock_eai.get_offerings = Mock(return_value=[
@@ -80,7 +71,6 @@ def test_info_crypto_offering_missing_chain_id_500(mock_eai, client):
     assert response.status_code == 500
 
 
-# --- 6.44 test_info_virtual_account_offering_missing_currency_500 ---
 @patch(f"{code_path}.eai")
 def test_info_virtual_account_offering_missing_currency_500(mock_eai, client):
     mock_eai.get_offerings = Mock(return_value=[
@@ -90,7 +80,6 @@ def test_info_virtual_account_offering_missing_currency_500(mock_eai, client):
     assert response.status_code == 500
 
 
-# --- 6.45 test_info_bank_account_offering_missing_rail_500 ---
 @patch(f"{code_path}.eai")
 def test_info_bank_account_offering_missing_rail_500(mock_eai, client):
     mock_eai.get_offerings = Mock(return_value=[

--- a/polaris/tests/sep58/test_info.py
+++ b/polaris/tests/sep58/test_info.py
@@ -1,0 +1,100 @@
+from unittest.mock import patch, Mock
+
+import pytest
+
+from polaris.tests.helpers import mock_check_auth_success
+
+INFO_ENDPOINT = "/sep58/info"
+code_path = "polaris.sep58.info"
+
+
+# --- 6.2 test_info_returns_offerings ---
+@patch(f"{code_path}.eai")
+def test_info_returns_offerings(mock_eai, client):
+    mock_eai.get_offerings = Mock(return_value=[
+        {"kind": "crypto_address", "chain_id": "eip155:1", "network": "Ethereum Mainnet"},
+    ])
+    response = client.get(INFO_ENDPOINT)
+    assert response.status_code == 200, response.content
+    body = response.json()
+    assert "offerings" in body
+    assert len(body["offerings"]) == 1
+    assert body["offerings"][0]["kind"] == "crypto_address"
+    mock_eai.get_offerings.assert_called_once()
+
+
+# --- 6.3 test_info_no_auth_required ---
+@patch(f"{code_path}.eai")
+def test_info_no_auth_required(mock_eai, client):
+    """No token provided — should still return 200, not 403."""
+    mock_eai.get_offerings = Mock(return_value=[])
+    response = client.get(INFO_ENDPOINT)
+    assert response.status_code == 200
+
+
+# --- 6.39 test_info_crypto_address_offering_valid ---
+@patch(f"{code_path}.eai")
+def test_info_crypto_address_offering_valid(mock_eai, client):
+    mock_eai.get_offerings = Mock(return_value=[
+        {"kind": "crypto_address", "chain_id": "eip155:1", "network": "Ethereum"},
+    ])
+    response = client.get(INFO_ENDPOINT)
+    assert response.status_code == 200
+
+
+# --- 6.40 test_info_virtual_account_offering_valid ---
+@patch(f"{code_path}.eai")
+def test_info_virtual_account_offering_valid(mock_eai, client):
+    mock_eai.get_offerings = Mock(return_value=[
+        {"kind": "virtual_account", "country_code": "US", "currency": "USD", "rail": "ACH"},
+    ])
+    response = client.get(INFO_ENDPOINT)
+    assert response.status_code == 200
+
+
+# --- 6.41 test_info_bank_account_offering_valid ---
+@patch(f"{code_path}.eai")
+def test_info_bank_account_offering_valid(mock_eai, client):
+    mock_eai.get_offerings = Mock(return_value=[
+        {"kind": "bank_account", "country_code": "MX", "currency": "MXN", "rail": "SPEI"},
+    ])
+    response = client.get(INFO_ENDPOINT)
+    assert response.status_code == 200
+
+
+# --- 6.42 test_info_offering_missing_kind_500 ---
+@patch(f"{code_path}.eai")
+def test_info_offering_missing_kind_500(mock_eai, client):
+    mock_eai.get_offerings = Mock(return_value=[{"country_code": "US"}])
+    response = client.get(INFO_ENDPOINT)
+    assert response.status_code == 500
+
+
+# --- 6.43 test_info_crypto_offering_missing_chain_id_500 ---
+@patch(f"{code_path}.eai")
+def test_info_crypto_offering_missing_chain_id_500(mock_eai, client):
+    mock_eai.get_offerings = Mock(return_value=[
+        {"kind": "crypto_address", "network": "Ethereum"},
+    ])
+    response = client.get(INFO_ENDPOINT)
+    assert response.status_code == 500
+
+
+# --- 6.44 test_info_virtual_account_offering_missing_currency_500 ---
+@patch(f"{code_path}.eai")
+def test_info_virtual_account_offering_missing_currency_500(mock_eai, client):
+    mock_eai.get_offerings = Mock(return_value=[
+        {"kind": "virtual_account", "country_code": "US", "rail": "ACH"},
+    ])
+    response = client.get(INFO_ENDPOINT)
+    assert response.status_code == 500
+
+
+# --- 6.45 test_info_bank_account_offering_missing_rail_500 ---
+@patch(f"{code_path}.eai")
+def test_info_bank_account_offering_missing_rail_500(mock_eai, client):
+    mock_eai.get_offerings = Mock(return_value=[
+        {"kind": "bank_account", "country_code": "MX", "currency": "MXN"},
+    ])
+    response = client.get(INFO_ENDPOINT)
+    assert response.status_code == 500

--- a/polaris/tests/test_register_integrations.py
+++ b/polaris/tests/test_register_integrations.py
@@ -8,6 +8,7 @@ from polaris.integrations import (
     SEP31ReceiverIntegration,
     CustomerIntegration,
     RailsIntegration,
+    ExternalAccountIntegration,
 )
 
 
@@ -21,6 +22,7 @@ def test_init_success_all_integrations():
     sep31 = SEP31ReceiverIntegration()
     customer = CustomerIntegration()
     rails = RailsIntegration()
+    external_account = ExternalAccountIntegration()
     callable = lambda x: None
     register_integrations(
         deposit=deposit,
@@ -31,12 +33,14 @@ def test_init_success_all_integrations():
         fee=callable,
         sep6_info=callable,
         toml=callable,
+        external_account=external_account,
     )
     assert integrations.registered_deposit_integration == deposit
     assert integrations.registered_withdrawal_integration == withdrawal
     assert integrations.registered_sep31_receiver_integration == sep31
     assert integrations.registered_customer_integration == customer
     assert integrations.registered_rails_integration == rails
+    assert integrations.registered_external_account_integration == external_account
     assert all(
         i == callable
         for i in [
@@ -60,3 +64,9 @@ def test_invalid_integration_params():
     ]:
         with pytest.raises(TypeError):
             register_integrations(**{kwarg: NonCallableMock()})
+
+
+# --- 6.48 ---
+def test_register_external_account_bad_type():
+    with pytest.raises(TypeError):
+        register_integrations(external_account="not an integration")

--- a/polaris/urls.py
+++ b/polaris/urls.py
@@ -39,3 +39,6 @@ if "sep-31" in settings.ACTIVE_SEPS:
 
 if "sep-38" in settings.ACTIVE_SEPS:
     urlpatterns.append(path("sep38/", include("polaris.sep38.urls")))
+
+if "sep-58" in settings.ACTIVE_SEPS:
+    urlpatterns.append(path("sep58/", include("polaris.sep58.urls")))


### PR DESCRIPTION
## Summary

- Adds SEP-58 External Account API support to Polaris with `ExternalAccountIntegration` base class
- Implements `/info`, `/accounts`, and `/accounts/:id` endpoints with full request/response validation
- Enforces HTTPS callback URLs, KYC dict-return convention (403), and per-kind field requirements
- Adds `EXTERNAL_ACCOUNT_SERVER` to stellar.toml discovery when `sep-58` is in `ACTIVE_SEPS`

## Changes

| File | Action |
|---|---|
| `polaris/integrations/external_account.py` | New integration base class |
| `polaris/integrations/__init__.py` | Registration wiring (+4 lines) |
| `polaris/settings.py` | Add `sep-58` to `accepted_seps` |
| `polaris/sep58/` | New module: `__init__.py`, `urls.py`, `info.py`, `accounts.py` |
| `polaris/urls.py` | Conditional URL inclusion |
| `polaris/sep1/views.py` | TOML discovery entry |
| `polaris/tests/sep58/` | 45 endpoint tests |
| `polaris/tests/test_register_integrations.py` | +2 registration tests |
| `polaris/tests/sep1/test_toml.py` | +sep-58 discovery assertions |

## Test plan

- [x] 45 new SEP-58 endpoint tests (request validation, error conventions, per-kind response shapes)
- [x] Registration and TOML discovery tests updated
- [x] Full suite: 627 passed, 0 failures