### PR TITLE
fix: return 400 for invalid SEP-10 transaction values

### DIFF
--- a/polaris/sep10/views.py
+++ b/polaris/sep10/views.py
@@ -178,6 +178,8 @@ class SEP10Auth(APIView):
         envelope_xdr = request.data.get("transaction")
         if not envelope_xdr:
             return render_error_response(gettext("'transaction' is required"))
+        if not isinstance(envelope_xdr, str):
+            return render_error_response(gettext("'transaction' must be a string"))
         client_domain, error_response = self._validate_challenge_xdr(envelope_xdr)
         if error_response:
             return error_response
@@ -208,7 +210,7 @@ class SEP10Auth(APIView):
                 web_auth_domain=urlparse(settings.HOST_URL).netloc,
                 network_passphrase=settings.STELLAR_NETWORK_PASSPHRASE,
             )
-        except (InvalidSep10ChallengeError, TypeError) as e:
+        except Exception as e:
             return None, render_error_response(generic_err_msg % (str(e)))
 
         client_domain = None


### PR DESCRIPTION
## Summary
- Add type check in `post()` to reject non-string `transaction` values with 400
- Broaden except in `_validate_challenge_xdr()` to catch all SDK parsing errors

Closes #6

## Test plan
- [ ] POST `/auth` with `{"transaction": {"key": true}}` returns 400
- [ ] POST `/auth` with `{"transaction": "not-base64"}` returns 400
- [ ] POST `/auth` with valid base64 challenge XDR still returns token